### PR TITLE
feat(chart): add imagePullSecrets support

### DIFF
--- a/versions/1.0.1/templates/manager.yaml
+++ b/versions/1.0.1/templates/manager.yaml
@@ -43,6 +43,10 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+{{- with (.Values.manager.imagePullSecrets | default .Values.imagePullSecrets) }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
       containers:
         - args:
             - --enable-leader-election
@@ -157,6 +161,10 @@ spec:
       labels:
         control-plane: daemon
     spec:
+{{- with (.Values.manager.imagePullSecrets | default .Values.imagePullSecrets) }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
 {{- if .Values.daemon.affinity }}
       affinity:
 {{ toYaml .Values.daemon.affinity | indent 8 }}

--- a/versions/1.0.1/templates/manager.yaml
+++ b/versions/1.0.1/templates/manager.yaml
@@ -43,7 +43,7 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-{{- with (.Values.manager.imagePullSecrets | default .Values.imagePullSecrets) }}
+{{- with .Values.imagePullSecrets }}
       imagePullSecrets:
 {{- toYaml . | nindent 8 }}
 {{- end }}
@@ -161,7 +161,7 @@ spec:
       labels:
         control-plane: daemon
     spec:
-{{- with (.Values.manager.imagePullSecrets | default .Values.imagePullSecrets) }}
+{{- with .Values.imagePullSecrets }}
       imagePullSecrets:
 {{- toYaml . | nindent 8 }}
 {{- end }}


### PR DESCRIPTION
Hi,

This PR introduces support for `imagePullSecrets` for both the manager deployment and the daemon ds. One can either declare those values globally or locally for each component. Motivations behind this change are:

- Authenticate to the registry in case of a custom, private image
- Getting rid of rate limitations for services like Dockerhub when pulling images onto a large cluster

Please let me know if anything looks wrong to you.

Thanks in advance for reviewing the code.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
