### PR TITLE
[Issue22] Fix_hardcoded_references_to_namespace

### DIFF
--- a/versions/kruise-rollout/0.2.0/templates/rbac_role.yaml
+++ b/versions/kruise-rollout/0.2.0/templates/rbac_role.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kruise-rollout-controller-manager
-  namespace: kruise-rollout
+  namespace: {{ .Values.installation.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kruise-rollout-leader-election-role
-  namespace: kruise-rollout
+  namespace: {{ .Values.installation.namespace }}
 rules:
   - apiGroups:
       - ""
@@ -335,7 +335,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kruise-rollout-leader-election-rolebinding
-  namespace: kruise-rollout
+  namespace: {{ .Values.installation.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -343,7 +343,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kruise-rollout-controller-manager
-    namespace: kruise-rollout
+    namespace: {{ .Values.installation.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -356,4 +356,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kruise-rollout-controller-manager
-    namespace: kruise-rollout
+    namespace: {{ .Values.installation.namespace }}

--- a/versions/kruise-rollout/0.2.0/templates/webhookconfiguration.yaml
+++ b/versions/kruise-rollout/0.2.0/templates/webhookconfiguration.yaml
@@ -9,7 +9,7 @@ webhooks:
     clientConfig:
       service:
         name: kruise-rollout-webhook-service
-        namespace: kruise-rollout
+        namespace: {{ .Values.installation.namespace }}
         path: /mutate-unified-workload
     failurePolicy: Fail
     name: munifiedworload.kb.io
@@ -34,7 +34,7 @@ webhooks:
     clientConfig:
       service:
         name: kruise-rollout-webhook-service
-        namespace: kruise-rollout
+        namespace: {{ .Values.installation.namespace }}
         path: /mutate-apps-kruise-io-v1alpha1-cloneset
     failurePolicy: Fail
     name: mcloneset.kb.io
@@ -54,7 +54,7 @@ webhooks:
     clientConfig:
       service:
         name: kruise-rollout-webhook-service
-        namespace: kruise-rollout
+        namespace: {{ .Values.installation.namespace }}
         path: /mutate-apps-v1-deployment
     failurePolicy: Fail
     name: mdeployment.kb.io
@@ -74,7 +74,7 @@ webhooks:
     clientConfig:
       service:
         name: kruise-rollout-webhook-service
-        namespace: kruise-rollout
+        namespace: {{ .Values.installation.namespace }}
         path: /mutate-apps-v1-statefulset
     failurePolicy: Fail
     name: mstatefulset.kb.io
@@ -94,7 +94,7 @@ webhooks:
     clientConfig:
       service:
         name: kruise-rollout-webhook-service
-        namespace: kruise-rollout
+        namespace: {{ .Values.installation.namespace }}
         path: /mutate-apps-kruise-io-statefulset
     failurePolicy: Fail
     name: madvancedstatefulset.kb.io
@@ -123,7 +123,7 @@ webhooks:
     clientConfig:
       service:
         name: kruise-rollout-webhook-service
-        namespace: kruise-rollout
+        namespace: {{ .Values.installation.namespace }}
         path: /validate-rollouts-kruise-io-rollout
     failurePolicy: Fail
     name: vrollout.kb.io

--- a/versions/kruise/1.3.0/templates/apps.kruise.io_statefulsets.yaml
+++ b/versions/kruise/1.3.0/templates/apps.kruise.io_statefulsets.yaml
@@ -14,7 +14,7 @@ spec:
       clientConfig:
         service:
           name: kruise-webhook-service
-          namespace: kruise-system
+          namespace: {{ .Values.installation.namespace }}
           path: /convert
       conversionReviewVersions:
       - v1

--- a/versions/kruise/1.3.0/templates/webhookconfiguration.yaml
+++ b/versions/kruise/1.3.0/templates/webhookconfiguration.yaml
@@ -312,7 +312,7 @@ webhooks:
     caBundle: Cg==
     service:
       name: kruise-webhook-service
-      namespace: kruise-system
+      namespace: {{ .Values.installation.namespace }}
       path: /validate-pod
   failurePolicy: Fail
   admissionReviewVersions:
@@ -634,7 +634,7 @@ webhooks:
   clientConfig:
     service:
       name: kruise-webhook-service
-      namespace: kruise-system
+      namespace: {{ .Values.installation.namespace }}
       path: /validate-apps-kruise-io-persistentpodstate
   failurePolicy: Fail
   name: vpersistentpodstate.kb.io
@@ -656,7 +656,7 @@ webhooks:
   clientConfig:
     service:
       name: webhook-service
-      namespace: system
+      namespace: {{ .Values.installation.namespace }}
       path: /validate-apps-kruise-io-podprobemarker
   failurePolicy: Fail
   name: vpodprobemarker.kb.io
@@ -675,7 +675,7 @@ webhooks:
     caBundle: Cg==
     service:
       name: kruise-webhook-service
-      namespace: kruise-system
+      namespace: {{ .Values.installation.namespace }}
       path: /validate-policy-kruise-io-podunavailablebudget
   failurePolicy: Fail
   admissionReviewVersions:


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
1. fix hardcoded references to namespace `kruise-system` which are not templated with the variable `{{ .Values.installation.namespace }}`.
It's related to [issue/1121](https://github.com/openkruise/kruise/issues/1121) and [issue/22](https://github.com/openkruise/charts/issues/22)
2. fix hardcoded references to namespace `kruise-rollout` which are not templated with the variable `{{ .Values.installation.namespace }}`.
### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #22 
### Ⅲ. Special notes for reviews
@FillZpp 
@zmberg  

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
