### PR TITLE
Allow to set extra environment variables on manager DaemonSet

### DIFF
--- a/versions/kruise/1.3.0/Chart.yaml
+++ b/versions/kruise/1.3.0/Chart.yaml
@@ -21,3 +21,4 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - "[Changed]: https://github.com/openkruise/kruise/blob/master/CHANGELOG.md"
+    - "[Changed]: Support extra environment variables in the manager DaemonSet"

--- a/versions/kruise/1.3.0/README.md
+++ b/versions/kruise/1.3.0/README.md
@@ -23,6 +23,7 @@ The following table lists the configurable parameters of the kruise chart and th
 | `manager.nodeAffinity`                    | Node affinity policy for kruise-manager pod                  | `{}`                          |
 | `manager.nodeSelector`                    | Node labels for kruise-manager pod                           | `{}`                          |
 | `manager.tolerations`                     | Tolerations for kruise-manager pod                           | `[]`                          |
+| `daemon.extraEnvs`                        | Extra environment variables that will be pass onto pods      | `[]`                          |
 | `daemon.log.level`                        | Log level that kruise-daemon printed                         | `4`                           |
 | `daemon.port`                             | Port of metrics and healthz that kruise-daemon served        | `10221`                       |
 | `daemon.pprofAddr`                        | Address of pprof served                                      | `localhost:10222`             |

--- a/versions/kruise/1.3.0/templates/manager.yaml
+++ b/versions/kruise/1.3.0/templates/manager.yaml
@@ -197,6 +197,9 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        {{- if .Values.daemon.extraEnvs }}
+        {{- toYaml .Values.daemon.extraEnvs | nindent 8 }}
+        {{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/versions/kruise/1.3.0/values.yaml
+++ b/versions/kruise/1.3.0/values.yaml
@@ -72,5 +72,17 @@ daemon:
       cpu: "0"
       memory: "0"
 
+  # Extra environment variables that will be pass onto pods.
+  # For example, when the daemon is used behind a http proxy, you can set the proxy environment variables here. 
+  # This will be appended to the current 'env:' key. You can use any of the kubernetes env
+  # syntax here.
+  extraEnvs: []
+  # - name: HTTP_PROXY
+  #   value: http://my-proxy:8080/
+  # - name: HTTPS_PROXY
+  #   value: http://my-proxy:8080/
+  # - name: NO_PROXY
+  #   value: localhost,0.0.0.0,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+
 serviceAccount:
   annotations: {}


### PR DESCRIPTION
### Describe what this PR does ###

This PR adds the possibility of set extra environment variables in the manager DaemonSet.
This allows for example to support corporate proxy when downloading images
with ImagePullJob setting the HTTP_PROXY, HTTPS_PROXY, NO_PROXY env vars.

### Does this pull request fix one issue? ###

Fixes https://github.com/openkruise/kruise/issues/1120

### Special notes for reviews ###

This is my first PR on this project. I tried to follow the contributing guidelines checklist, bumping also a new beta version for changes. Let me know if it's preferable to move the PR to an existing version. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
