### PR TITLE
Fix: fail to install Kruise rollout in customized namespace

### DIFF
--- a/versions/kruise-rollout/0.1.0/templates/manager.yaml
+++ b/versions/kruise-rollout/0.1.0/templates/manager.yaml
@@ -40,7 +40,7 @@ spec:
       labels:
         control-plane: {{ .Values.rollout.fullname }}
     spec:
-      serviceAccountName: {{ .Values.rollout.fullname }}
+      serviceAccountName: {{ template "rollout.name" . }}-controller-manager
       containers:
         - name: {{ .Chart.Name }}
           args:

--- a/versions/kruise-rollout/0.3.0-rc/templates/rbac_role.yaml
+++ b/versions/kruise-rollout/0.3.0-rc/templates/rbac_role.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.installation.namespace }}-controller-manager
+  name: {{ template "rollout.name" . }}-controller-manager
   namespace: {{ .Values.installation.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.installation.namespace }}-leader-election-role
+  name: {{ template "rollout.name" . }}-leader-election-role
   namespace: {{ .Values.installation.namespace }}
 rules:
   - apiGroups:
@@ -48,7 +48,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: {{ .Values.installation.namespace }}-manager-role
+  name: {{ template "rollout.name" . }}-manager-role
 rules:
   - apiGroups:
       - '*'
@@ -370,26 +370,26 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.installation.namespace }}-leader-election-rolebinding
+  name: {{ template "rollout.name" . }}-leader-election-rolebinding
   namespace: {{ .Values.installation.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Values.installation.namespace }}-leader-election-role
+  name: {{ template "rollout.name" . }}-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.installation.namespace }}-controller-manager
+    name: {{ template "rollout.name" . }}-controller-manager
     namespace: {{ .Values.installation.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.installation.namespace }}-manager-rolebinding
+  name: {{ template "rollout.name" . }}-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.installation.namespace }}-manager-role
+  name: {{ template "rollout.name" . }}-manager-role
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.installation.namespace }}-controller-manager
+    name: {{ template "rollout.name" . }}-controller-manager
     namespace: {{ .Values.installation.namespace }}

--- a/versions/kruise-rollout/0.3.0-rc/templates/webhookconfiguration.yaml
+++ b/versions/kruise-rollout/0.3.0-rc/templates/webhookconfiguration.yaml
@@ -3,14 +3,14 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: {{ .Values.installation.namespace }}-mutating-webhook-configuration
+  name: {{ template "rollout.name" . }}-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
       - v1
       - v1beta1
     clientConfig:
       service:
-        name: {{ .Values.installation.namespace }}-webhook-service
+        name: {{ template "rollout.name" . }}-webhook-service
         namespace: {{ .Values.installation.namespace }}
         path: /mutate-unified-workload
     failurePolicy: Fail
@@ -35,7 +35,7 @@ webhooks:
       - v1beta1
     clientConfig:
       service:
-        name: {{ .Values.installation.namespace }}-webhook-service
+        name: {{ template "rollout.name" . }}-webhook-service
         namespace: {{ .Values.installation.namespace }}
         path: /mutate-apps-v1-deployment
     failurePolicy: Fail
@@ -61,7 +61,7 @@ webhooks:
       - v1beta1
     clientConfig:
       service:
-        name: {{ .Values.installation.namespace }}-webhook-service
+        name: {{ template "rollout.name" . }}-webhook-service
         namespace: {{ .Values.installation.namespace }}
         path: /mutate-apps-kruise-io-v1alpha1-cloneset
     failurePolicy: Fail
@@ -123,7 +123,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: {{ .Values.installation.namespace }}-validating-webhook-configuration
+  name: {{ template "rollout.name" . }}-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
       - v1


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>

Fix: #36 

Investigation:
The namespace could be specified by user, when he run  helm install with
 --set installation.namespace=myroll 

but serviceaccount and webhook's names are binded with NS. That makes pod run into error state

How to fix it?
Just set there names with "rollout.name", which is defined in helm template file.

How to test it:
run 
```
 helm install  krollout ./kruise-rollout --set installation.namespace=myroll --set image.pullPolicy="IfNotPresent" --debug

```
to install this Chart, and all Pod can be up successfully.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
