### PR TITLE
[Fix] charts large number of field structure errors exist

### DIFF
--- a/versions/kruise/1.4/templates/apps.kruise.io_sidecarsets.yaml
+++ b/versions/kruise/1.4/templates/apps.kruise.io_sidecarsets.yaml
@@ -256,6 +256,51 @@ spec:
                 description: Namespace sidecarSet will only match the pods in the
                   namespace otherwise, match pods in all namespaces(in cluster)
                 type: string
+              namespaceSelector:
+                description: NamespaceSelector select which namespaces to inject sidecar
+                  containers. Default to the empty LabelSelector, which matches everything.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
               patchPodMetadata:
                 description: SidecarSet support to inject & in-place update metadata
                   in pod.

--- a/versions/kruise/1.4/templates/apps.kruise.io_statefulsets.yaml
+++ b/versions/kruise/1.4/templates/apps.kruise.io_statefulsets.yaml
@@ -8,17 +8,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   name: statefulsets.apps.kruise.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: kruise-webhook-service
-          namespace: {{ .Values.installation.namespace }}
-          path: /convert
-      conversionReviewVersions:
-      - v1
-      - v1beta1
   group: apps.kruise.io
   names:
     kind: StatefulSet

--- a/versions/kruise/1.4/templates/apps.kruise.io_workloadspreads.yaml
+++ b/versions/kruise/1.4/templates/apps.kruise.io_workloadspreads.yaml
@@ -39,10 +39,14 @@ spec:
         description: WorkloadSpread is the Schema for the WorkloadSpread API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -50,21 +54,34 @@ spec:
             description: WorkloadSpreadSpec defines the desired state of WorkloadSpread.
             properties:
               scheduleStrategy:
-                description: ScheduleStrategy indicates the strategy the WorkloadSpread used to preform the schedule between each of subsets.
+                description: ScheduleStrategy indicates the strategy the WorkloadSpread
+                  used to preform the schedule between each of subsets.
                 properties:
                   adaptive:
-                    description: Adaptive is used to communicate parameters when Type is AdaptiveWorkloadSpreadScheduleStrategyType.
+                    description: Adaptive is used to communicate parameters when Type
+                      is AdaptiveWorkloadSpreadScheduleStrategyType.
                     properties:
                       disableSimulationSchedule:
-                        description: DisableSimulationSchedule indicates whether to disable the feature of simulation schedule. Default is false. Webhook can take a simple general predicates to check whether Pod can be scheduled into this subset, but it just considers the Node resource and cannot replace scheduler to do richer predicates practically.
+                        description: DisableSimulationSchedule indicates whether to
+                          disable the feature of simulation schedule. Default is false.
+                          Webhook can take a simple general predicates to check whether
+                          Pod can be scheduled into this subset, but it just considers
+                          the Node resource and cannot replace scheduler to do richer
+                          predicates practically.
                         type: boolean
                       rescheduleCriticalSeconds:
-                        description: RescheduleCriticalSeconds indicates how long controller will reschedule a schedule failed Pod to the subset that has redundant capacity after the subset where the Pod lives. If a Pod was scheduled failed and still in a unschedulabe status over RescheduleCriticalSeconds duration, the controller will reschedule it to a suitable subset.
+                        description: RescheduleCriticalSeconds indicates how long
+                          controller will reschedule a schedule failed Pod to the
+                          subset that has redundant capacity after the subset where
+                          the Pod lives. If a Pod was scheduled failed and still in
+                          a unschedulabe status over RescheduleCriticalSeconds duration,
+                          the controller will reschedule it to a suitable subset.
                         format: int32
                         type: integer
                     type: object
                   type:
-                    description: Type indicates the type of the WorkloadSpreadScheduleStrategy. Default is Fixed
+                    description: Type indicates the type of the WorkloadSpreadScheduleStrategy.
+                      Default is Fixed
                     enum:
                     - Adaptive
                     - Fixed
@@ -72,7 +89,8 @@ spec:
                     type: string
                 type: object
               subsets:
-                description: Subsets describes the pods distribution details between each of subsets.
+                description: Subsets describes the pods distribution details between
+                  each of subsets.
                 items:
                   description: WorkloadSpreadSubset defines the details of a subset.
                   properties:
@@ -80,35 +98,55 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: MaxReplicas indicates the desired max replicas of this subset.
+                      description: MaxReplicas indicates the desired max replicas
+                        of this subset.
                       x-kubernetes-int-or-string: true
                     name:
-                      description: Name should be unique between all of the subsets under one WorkloadSpread.
+                      description: Name should be unique between all of the subsets
+                        under one WorkloadSpread.
                       type: string
                     patch:
                       description: Patch indicates patching podTemplate to the Pod.
                       x-kubernetes-preserve-unknown-fields: true
                     preferredNodeSelectorTerms:
-                      description: Indicates the node preferred selector to form the subset.
+                      description: Indicates the node preferred selector to form the
+                        subset.
                       items:
-                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
                         properties:
                           preference:
-                            description: A node selector term, associated with the corresponding weight.
+                            description: A node selector term, associated with the
+                              corresponding weight.
                             properties:
                               matchExpressions:
-                                description: A list of node selector requirements by node's labels.
+                                description: A list of node selector requirements
+                                  by node's labels.
                                 items:
-                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
-                                      description: The label key that the selector applies to.
+                                      description: The label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
-                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
                                       type: string
                                     values:
-                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -118,18 +156,31 @@ spec:
                                   type: object
                                 type: array
                               matchFields:
-                                description: A list of node selector requirements by node's fields.
+                                description: A list of node selector requirements
+                                  by node's fields.
                                 items:
-                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
-                                      description: The label key that the selector applies to.
+                                      description: The label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
-                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
                                       type: string
                                     values:
-                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -140,7 +191,8 @@ spec:
                                 type: array
                             type: object
                           weight:
-                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
                             format: int32
                             type: integer
                         required:
@@ -149,21 +201,34 @@ spec:
                         type: object
                       type: array
                     requiredNodeSelectorTerm:
-                      description: Indicates the node required selector to form the subset.
+                      description: Indicates the node required selector to form the
+                        subset.
                       properties:
                         matchExpressions:
-                          description: A list of node selector requirements by node's labels.
+                          description: A list of node selector requirements by node's
+                            labels.
                           items:
-                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
                             properties:
                               key:
-                                description: The label key that the selector applies to.
+                                description: The label key that the selector applies
+                                  to.
                                 type: string
                               operator:
-                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -173,18 +238,30 @@ spec:
                             type: object
                           type: array
                         matchFields:
-                          description: A list of node selector requirements by node's fields.
+                          description: A list of node selector requirements by node's
+                            fields.
                           items:
-                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
                             properties:
                               key:
-                                description: The label key that the selector applies to.
+                                description: The label key that the selector applies
+                                  to.
                                 type: string
                               operator:
-                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -195,25 +272,45 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: Indicates the tolerations the pods under this subset have.
+                      description: Indicates the tolerations the pods under this subset
+                        have.
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
@@ -222,7 +319,8 @@ spec:
                   type: object
                 type: array
               targetRef:
-                description: TargetReference is the target workload that WorkloadSpread want to control.
+                description: TargetReference is the target workload that WorkloadSpread
+                  want to control.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -246,30 +344,38 @@ spec:
             description: WorkloadSpreadStatus defines the observed state of WorkloadSpread.
             properties:
               observedGeneration:
-                description: ObservedGeneration is the most recent generation observed for this WorkloadSpread. It corresponds to the WorkloadSpread's generation, which is updated on mutation by the API Server.
+                description: ObservedGeneration is the most recent generation observed
+                  for this WorkloadSpread. It corresponds to the WorkloadSpread's
+                  generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               subsetStatuses:
-                description: Contains the status of each subset. Each element in this array represents one subset
+                description: Contains the status of each subset. Each element in this
+                  array represents one subset
                 items:
-                  description: WorkloadSpreadSubsetStatus defines the observed state of subset
+                  description: WorkloadSpreadSubsetStatus defines the observed state
+                    of subset
                   properties:
                     conditions:
-                      description: Conditions is an array of current observed subset conditions.
+                      description: Conditions is an array of current observed subset
+                        conditions.
                       items:
                         properties:
                           lastTransitionTime:
-                            description: Last time the condition transitioned from one status to another.
+                            description: Last time the condition transitioned from
+                              one status to another.
                             format: date-time
                             type: string
                           message:
-                            description: A human readable message indicating details about the transition.
+                            description: A human readable message indicating details
+                              about the transition.
                             type: string
                           reason:
                             description: The reason for the condition's last transition.
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             type: string
                           type:
                             description: Type of in place set condition.
@@ -283,23 +389,43 @@ spec:
                       additionalProperties:
                         format: date-time
                         type: string
-                      description: CreatingPods contains information about pods whose creation was processed by the webhook handler but not yet been observed by the WorkloadSpread controller. A pod will be in this map from the time when the webhook handler processed the creation request to the time when the pod is seen by controller. The key in the map is the name of the pod and the value is the time when the webhook handler process the creation request. If the real creation didn't happen and a pod is still in this map, it will be removed from the list automatically by WorkloadSpread controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod creations.
+                      description: CreatingPods contains information about pods whose
+                        creation was processed by the webhook handler but not yet
+                        been observed by the WorkloadSpread controller. A pod will
+                        be in this map from the time when the webhook handler processed
+                        the creation request to the time when the pod is seen by controller.
+                        The key in the map is the name of the pod and the value is
+                        the time when the webhook handler process the creation request.
+                        If the real creation didn't happen and a pod is still in this
+                        map, it will be removed from the list automatically by WorkloadSpread
+                        controller after some time. If everything goes smooth this
+                        map should be empty for the most of the time. Large number
+                        of entries in the map may indicate problems with pod creations.
                       type: object
                     deletingPods:
                       additionalProperties:
                         format: date-time
                         type: string
-                      description: DeletingPods is similar with CreatingPods and it contains information about pod deletion.
+                      description: DeletingPods is similar with CreatingPods and it
+                        contains information about pod deletion.
                       type: object
                     missingReplicas:
-                      description: MissingReplicas is the number of active replicas belong to this subset not be found. MissingReplicas > 0 indicates the subset is still missing MissingReplicas pods to create MissingReplicas = 0 indicates the subset already has enough pods, there is no need to create MissingReplicas = -1 indicates the subset's MaxReplicas not set, then there is no limit for pods number
+                      description: MissingReplicas is the number of active replicas
+                        belong to this subset not be found. MissingReplicas > 0 indicates
+                        the subset is still missing MissingReplicas pods to create
+                        MissingReplicas = 0 indicates the subset already has enough
+                        pods, there is no need to create MissingReplicas = -1 indicates
+                        the subset's MaxReplicas not set, then there is no limit for
+                        pods number
                       format: int32
                       type: integer
                     name:
-                      description: Name should be unique between all of the subsets under one WorkloadSpread.
+                      description: Name should be unique between all of the subsets
+                        under one WorkloadSpread.
                       type: string
                     replicas:
-                      description: Replicas is the most recently observed number of active replicas for subset.
+                      description: Replicas is the most recently observed number of
+                        active replicas for subset.
                       format: int32
                       type: integer
                   required:

--- a/versions/kruise/1.4/templates/policy.kruise.io_podunavailablebudgets.yaml
+++ b/versions/kruise/1.4/templates/policy.kruise.io_podunavailablebudgets.yaml
@@ -20,7 +20,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: UnavailableAllowed number of pod unavailable that are currently allowed
+    - description: UnavailableAllowed number of pod unavailable that are currently
+        allowed
       jsonPath: .status.unavailableAllowed
       name: Allowed
       type: integer
@@ -39,13 +40,18 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PodUnavailableBudget is the Schema for the podunavailablebudgets API
+        description: PodUnavailableBudget is the Schema for the podunavailablebudgets
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -56,30 +62,47 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: Delete pod, evict pod or update pod specification is allowed if at most "maxUnavailable" pods selected by "selector" or "targetRef"  are unavailable after the above operation for pod. MaxUnavailable and MinAvailable are mutually exclusive, MaxUnavailable is priority to take effect
+                description: Delete pod, evict pod or update pod specification is
+                  allowed if at most "maxUnavailable" pods selected by "selector"
+                  or "targetRef"  are unavailable after the above operation for pod.
+                  MaxUnavailable and MinAvailable are mutually exclusive, MaxUnavailable
+                  is priority to take effect
                 x-kubernetes-int-or-string: true
               minAvailable:
                 anyOf:
                 - type: integer
                 - type: string
-                description: Delete pod, evict pod or update pod specification is allowed if at least "minAvailable" pods selected by "selector" or "targetRef" will still be available after the above operation for pod.
+                description: Delete pod, evict pod or update pod specification is
+                  allowed if at least "minAvailable" pods selected by "selector" or
+                  "targetRef" will still be available after the above operation for
+                  pod.
                 x-kubernetes-int-or-string: true
               selector:
                 description: Selector label query over pods managed by the budget
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -91,11 +114,17 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
                     type: object
                 type: object
               targetRef:
-                description: TargetReference contains enough information to let you identify an workload for PodUnavailableBudget Selector and TargetReference are mutually exclusive, TargetReference is priority to take effect
+                description: TargetReference contains enough information to let you
+                  identify an workload for PodUnavailableBudget Selector and TargetReference
+                  are mutually exclusive, TargetReference is priority to take effect
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -109,39 +138,49 @@ spec:
                 type: object
             type: object
           status:
-            description: PodUnavailableBudgetStatus defines the observed state of PodUnavailableBudget
+            description: PodUnavailableBudgetStatus defines the observed state of
+              PodUnavailableBudget
             properties:
               currentAvailable:
                 description: CurrentAvailable current number of available pods
                 format: int32
                 type: integer
               desiredAvailable:
-                description: DesiredAvailable minimum desired number of available pods
+                description: DesiredAvailable minimum desired number of available
+                  pods
                 format: int32
                 type: integer
               disruptedPods:
                 additionalProperties:
                   format: date-time
                   type: string
-                description: DisruptedPods contains information about pods whose eviction or deletion was processed by the API handler but has not yet been observed by the PodUnavailableBudget.
+                description: DisruptedPods contains information about pods whose eviction
+                  or deletion was processed by the API handler but has not yet been
+                  observed by the PodUnavailableBudget.
                 type: object
               observedGeneration:
-                description: Most recent generation observed when updating this PUB status. UnavailableAllowed and other status information is valid only if observedGeneration equals to PUB's object generation.
+                description: Most recent generation observed when updating this PUB
+                  status. UnavailableAllowed and other status information is valid
+                  only if observedGeneration equals to PUB's object generation.
                 format: int64
                 type: integer
               totalReplicas:
-                description: TotalReplicas total number of pods counted by this unavailable budget
+                description: TotalReplicas total number of pods counted by this unavailable
+                  budget
                 format: int32
                 type: integer
               unavailableAllowed:
-                description: UnavailableAllowed number of pod unavailable that are currently allowed
+                description: UnavailableAllowed number of pod unavailable that are
+                  currently allowed
                 format: int32
                 type: integer
               unavailablePods:
                 additionalProperties:
                   format: date-time
                   type: string
-                description: UnavailablePods contains information about pods whose specification changed(inplace-update pod), once pod is available(consistent and ready) again, it will be removed from the list.
+                description: UnavailablePods contains information about pods whose
+                  specification changed(inplace-update pod), once pod is available(consistent
+                  and ready) again, it will be removed from the list.
                 type: object
             required:
             - currentAvailable


### PR DESCRIPTION
```
I replaced yaml in kruise version 1.4 and fixed yaml in charts. A large number of inconsistencies were found.
```
![image](https://github.com/openkruise/charts/assets/38821215/ba66bbcf-548d-4f3d-80a0-90e390bb5ef2)
![image](https://github.com/openkruise/charts/assets/38821215/d1cfd4c0-70b4-4f27-890e-204ba9ca5d35)
![image](https://github.com/openkruise/charts/assets/38821215/841f887a-4741-4b99-b4d1-5d4927dbe42b)


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
