### PR TITLE
kruise rollout support tolerations

### DIFF
--- a/versions/kruise-rollout/0.4/templates/manager.yaml
+++ b/versions/kruise-rollout/0.4/templates/manager.yaml
@@ -96,3 +96,7 @@ spec:
                         - {{ .Values.rollout.fullname }}
                 topologyKey: kubernetes.io/hostname
               weight: 100
+      {{- with .Values.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/versions/kruise-rollout/0.4/values.yaml
+++ b/versions/kruise-rollout/0.4/values.yaml
@@ -59,3 +59,13 @@ resources:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+tolerations:
+# Toleration represents the toleration object that can be attached to a pod.
+# The pod this Toleration is attached to tolerates any taint that matches
+# the triple <key,value,effect> using the matching operator <operator>.
+# you could find more info at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# - effect: NoSchedule
+#   key: test
+#   operator: Equal
+#   value: hello


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
