### PR TITLE
rename kruise rollout clsuterrole name by clusterrolebinding ref

### DIFF
--- a/versions/kruise-rollout/0.4/templates/rbac_role.yaml
+++ b/versions/kruise-rollout/0.4/templates/rbac_role.yaml
@@ -48,7 +48,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: kruise-rollout-manager-role
+  name: {{ template "rollout.name" . }}-manager-role
 rules:
 - apiGroups:
   - '*'


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
