### PR TITLE
Add 1.5.1 kruise charts

### DIFF
--- a/versions/kruise/1.5.1/templates/apps.kruise.io_uniteddeployments.yaml
+++ b/versions/kruise/1.5.1/templates/apps.kruise.io_uniteddeployments.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: uniteddeployments.apps.kruise.io
 spec:
@@ -15,797 +15,803 @@ spec:
     listKind: UnitedDeploymentList
     plural: uniteddeployments
     shortNames:
-      - ud
+    - ud
     singular: uniteddeployment
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The desired number of pods.
-          jsonPath: .spec.replicas
-          name: DESIRED
-          type: integer
-        - description: The number of currently all pods.
-          jsonPath: .status.replicas
-          name: CURRENT
-          type: integer
-        - description: The number of pods updated.
-          jsonPath: .status.updatedReplicas
-          name: UPDATED
-          type: integer
-        - description: The number of pods ready.
-          jsonPath: .status.readyReplicas
-          name: READY
-          type: integer
-        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-          jsonPath: .metadata.creationTimestamp
-          name: AGE
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: UnitedDeployment is the Schema for the uniteddeployments API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: UnitedDeploymentSpec defines the desired state of UnitedDeployment.
-              properties:
-                replicas:
-                  description: Replicas is the total desired replicas of all the subsets. If unspecified, defaults to 1.
-                  format: int32
-                  type: integer
-                revisionHistoryLimit:
-                  description: Indicates the number of histories to be conserved. If unspecified, defaults to 10.
-                  format: int32
-                  type: integer
-                selector:
-                  description: Selector is a label query over pods that should match the replica count. It must match the pod template's labels.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+  - additionalPrinterColumns:
+    - description: The desired number of pods.
+      jsonPath: .spec.replicas
+      name: DESIRED
+      type: integer
+    - description: The number of currently all pods.
+      jsonPath: .status.replicas
+      name: CURRENT
+      type: integer
+    - description: The number of pods updated.
+      jsonPath: .status.updatedReplicas
+      name: UPDATED
+      type: integer
+    - description: The number of pods ready.
+      jsonPath: .status.readyReplicas
+      name: READY
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: UnitedDeployment is the Schema for the uniteddeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UnitedDeploymentSpec defines the desired state of UnitedDeployment.
+            properties:
+              replicas:
+                description: Replicas is the total desired replicas of all the subsets. If unspecified, defaults to 1.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: Indicates the number of histories to be conserved. If unspecified, defaults to 10.
+                format: int32
+                type: integer
+              selector:
+                description: Selector is a label query over pods that should match the replica count. It must match the pod template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template describes the subset that will be created.
+                properties:
+                  advancedStatefulSetTemplate:
+                    description: AdvancedStatefulSet template
+                    properties:
+                      metadata:
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        description: StatefulSetSpec defines the desired state of StatefulSet
                         properties:
-                          key:
-                            description: key is the label key that the selector applies to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                template:
-                  description: Template describes the subset that will be created.
-                  properties:
-                    advancedStatefulSetTemplate:
-                      description: AdvancedStatefulSet template
-                      properties:
-                        metadata:
-                          x-kubernetes-preserve-unknown-fields: true
-                        spec:
-                          description: StatefulSetSpec defines the desired state of StatefulSet
-                          properties:
-                            lifecycle:
-                              description: Lifecycle defines the lifecycle hooks for Pods pre-delete, in-place update.
-                              properties:
-                                inPlaceUpdate:
-                                  description: InPlaceUpdate is the hook before Pod to update and after Pod has been updated.
-                                  properties:
-                                    finalizersHandler:
-                                      items:
-                                        type: string
-                                      type: array
-                                    labelsHandler:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    markPodNotReady:
-                                      description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
-                                      type: boolean
-                                  type: object
-                                preDelete:
-                                  description: PreDelete is the hook before Pod to be deleted.
-                                  properties:
-                                    finalizersHandler:
-                                      items:
-                                        type: string
-                                      type: array
-                                    labelsHandler:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    markPodNotReady:
-                                      description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
-                                      type: boolean
-                                  type: object
-                                preNormal:
-                                  description: PreNormal is the hook after Pod to be created and ready to be Normal.
-                                  properties:
-                                    finalizersHandler:
-                                      items:
-                                        type: string
-                                      type: array
-                                    labelsHandler:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    markPodNotReady:
-                                      description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
-                                      type: boolean
-                                  type: object
-                              type: object
-                            persistentVolumeClaimRetentionPolicy:
-                              description: PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates. This requires the StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.
-                              properties:
-                                whenDeleted:
-                                  description: WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted. The default policy of `Retain` causes PVCs to not be affected by StatefulSet deletion. The `Delete` policy causes those PVCs to be deleted.
-                                  type: string
-                                whenScaled:
-                                  description: WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down. The default policy of `Retain` causes PVCs to not be affected by a scaledown. The `Delete` policy causes the associated PVCs for any excess pods above the replica count to be deleted.
-                                  type: string
-                              type: object
-                            podManagementPolicy:
-                              description: podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
-                              type: string
-                            replicas:
-                              description: 'replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1. TODO: Consider a rename of this field.'
-                              format: int32
-                              type: integer
-                            reserveOrdinals:
-                              description: 'reserveOrdinals controls the ordinal numbers that should be reserved, and the replicas will always be the expectation number of running Pods. For a sts with replicas=3 and its Pods in [0, 1, 2]: - If you want to migrate Pod-1 and reserve this ordinal, just set spec.reserveOrdinal to [1].   Then controller will delete Pod-1 and create Pod-3 (existing Pods will be [0, 2, 3]) - If you just want to delete Pod-1, you should set spec.reserveOrdinal to [1] and spec.replicas to 2.   Then controller will delete Pod-1 (existing Pods will be [0, 2])'
-                              items:
-                                type: integer
-                              type: array
-                            revisionHistoryLimit:
-                              description: revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
-                              format: int32
-                              type: integer
-                            scaleStrategy:
-                              description: scaleStrategy indicates the StatefulSetScaleStrategy that will be employed to scale Pods in the StatefulSet.
-                              properties:
-                                maxUnavailable:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  description: 'The maximum number of pods that can be unavailable during scaling. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. It can just be allowed to work with Parallel podManagementPolicy.'
-                                  x-kubernetes-int-or-string: true
-                              type: object
-                            selector:
-                              description: 'selector is a label query over pods that should match the replica count. It must match the pod template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                      - key
-                                      - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                  type: object
-                              type: object
-                            serviceName:
-                              description: 'serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.'
-                              type: string
-                            template:
-                              description: template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
-                              x-kubernetes-preserve-unknown-fields: true
-                            updateStrategy:
-                              description: updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
-                              properties:
-                                rollingUpdate:
-                                  description: RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
-                                  properties:
-                                    inPlaceUpdateStrategy:
-                                      description: InPlaceUpdateStrategy contains strategies for in-place update.
-                                      properties:
-                                        gracePeriodSeconds:
-                                          description: GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec when in-place update a Pod.
-                                          format: int32
-                                          type: integer
-                                      type: object
-                                    maxUnavailable:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. Also, maxUnavailable can just be allowed to work with Parallel podManagementPolicy. Defaults to 1.'
-                                      x-kubernetes-int-or-string: true
-                                    minReadySeconds:
-                                      description: MinReadySeconds indicates how long will the pod be considered ready after it's updated. MinReadySeconds works with both OrderedReady and Parallel podManagementPolicy. It affects the pod scale up speed when the podManagementPolicy is set to be OrderedReady. Combined with MaxUnavailable, it affects the pod update speed regardless of podManagementPolicy. Default value is 0, max is 300.
-                                      format: int32
-                                      type: integer
-                                    partition:
-                                      description: 'Partition indicates the ordinal at which the StatefulSet should be partitioned by default. But if unorderedUpdate has been set:   - Partition indicates the number of pods with non-updated revisions when rolling update.   - It means controller will update $(replicas - partition) number of pod. Default value is 0.'
-                                      format: int32
-                                      type: integer
-                                    paused:
-                                      description: Paused indicates that the StatefulSet is paused. Default value is false
-                                      type: boolean
-                                    podUpdatePolicy:
-                                      description: PodUpdatePolicy indicates how pods should be updated Default value is "ReCreate"
-                                      type: string
-                                    unorderedUpdate:
-                                      description: UnorderedUpdate contains strategies for non-ordered update. If it is not nil, pods will be updated with non-ordered sequence. Noted that UnorderedUpdate can only be allowed to work with Parallel podManagementPolicy
-                                      properties:
-                                        priorityStrategy:
-                                          description: Priorities are the rules for calculating the priority of updating pods. Each pod to be updated, will pass through these terms and get a sum of weights.
-                                          properties:
-                                            orderPriority:
-                                              description: 'Order priority terms, pods will be sorted by the value of orderedKey. For example: ``` orderPriority: - orderedKey: key1 - orderedKey: key2 ``` First, all pods which have key1 in labels will be sorted by the value of key1. Then, the left pods which have no key1 but have key2 in labels will be sorted by the value of key2 and put behind those pods have key1.'
-                                              items:
-                                                description: UpdatePriorityOrderTerm defines order priority.
-                                                properties:
-                                                  orderedKey:
-                                                    description: Calculate priority by value of this key. Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value, such as getting 5 in value '5', getting 10 in value 'sts-10'.
-                                                    type: string
-                                                required:
-                                                  - orderedKey
-                                                type: object
-                                              type: array
-                                            weightPriority:
-                                              description: Weight priority terms, pods will be sorted by the sum of all terms weight.
-                                              items:
-                                                description: UpdatePriorityWeightTerm defines weight priority.
-                                                properties:
-                                                  matchSelector:
-                                                    description: MatchSelector is used to select by pod's labels.
-                                                    properties:
-                                                      matchExpressions:
-                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                        items:
-                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                                          properties:
-                                                            key:
-                                                              description: key is the label key that the selector applies to.
-                                                              type: string
-                                                            operator:
-                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                              type: string
-                                                            values:
-                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchLabels:
-                                                        additionalProperties:
-                                                          type: string
-                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                                        type: object
-                                                    type: object
-                                                  weight:
-                                                    description: Weight associated with matching the corresponding matchExpressions, in the range 1-100.
-                                                    format: int32
-                                                    type: integer
-                                                required:
-                                                  - matchSelector
-                                                  - weight
-                                                type: object
-                                              type: array
-                                          type: object
-                                      type: object
-                                  type: object
-                                type:
-                                  description: Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
-                                  type: string
-                              type: object
-                            volumeClaimTemplates:
-                              description: 'volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name. TODO: Define the behavior if a claim already exists with the same name.'
-                              x-kubernetes-preserve-unknown-fields: true
-                          required:
-                            - selector
-                            - template
-                          type: object
-                      required:
-                        - spec
-                      type: object
-                    cloneSetTemplate:
-                      description: CloneSet template
-                      properties:
-                        metadata:
-                          x-kubernetes-preserve-unknown-fields: true
-                        spec:
-                          description: CloneSetSpec defines the desired state of CloneSet
-                          properties:
-                            lifecycle:
-                              description: Lifecycle defines the lifecycle hooks for Pods pre-available(pre-normal), pre-delete, in-place update.
-                              properties:
-                                inPlaceUpdate:
-                                  description: InPlaceUpdate is the hook before Pod to update and after Pod has been updated.
-                                  properties:
-                                    finalizersHandler:
-                                      items:
-                                        type: string
-                                      type: array
-                                    labelsHandler:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    markPodNotReady:
-                                      description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
-                                      type: boolean
-                                  type: object
-                                preDelete:
-                                  description: PreDelete is the hook before Pod to be deleted.
-                                  properties:
-                                    finalizersHandler:
-                                      items:
-                                        type: string
-                                      type: array
-                                    labelsHandler:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    markPodNotReady:
-                                      description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
-                                      type: boolean
-                                  type: object
-                                preNormal:
-                                  description: PreNormal is the hook after Pod to be created and ready to be Normal.
-                                  properties:
-                                    finalizersHandler:
-                                      items:
-                                        type: string
-                                      type: array
-                                    labelsHandler:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    markPodNotReady:
-                                      description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
-                                      type: boolean
-                                  type: object
-                              type: object
-                            minReadySeconds:
-                              description: Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
-                              format: int32
-                              type: integer
-                            replicas:
-                              description: Replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template. If unspecified, defaults to 1.
-                              format: int32
-                              type: integer
-                            revisionHistoryLimit:
-                              description: RevisionHistoryLimit is the maximum number of revisions that will be maintained in the CloneSet's revision history. The revision history consists of all revisions not represented by a currently applied CloneSetSpec version. The default value is 10.
-                              format: int32
-                              type: integer
-                            scaleStrategy:
-                              description: ScaleStrategy indicates the ScaleStrategy that will be employed to create and delete Pods in the CloneSet.
-                              properties:
-                                disablePVCReuse:
-                                  description: Indicate if cloneSet will reuse already existed pvc to rebuild a new pod
-                                  type: boolean
-                                maxUnavailable:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  description: The maximum number of pods that can be unavailable for scaled pods. This field can control the changes rate of replicas for CloneSet so as to minimize the impact for users' service. The scale will fail if the number of unavailable pods were greater than this MaxUnavailable at scaling up. MaxUnavailable works only when scaling up.
-                                  x-kubernetes-int-or-string: true
-                                podsToDelete:
-                                  description: PodsToDelete is the names of Pod should be deleted. Note that this list will be truncated for non-existing pod names.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            selector:
-                              description: 'Selector is a label query over pods that should match the replica count. It must match the pod template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                      - key
-                                      - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                  type: object
-                              type: object
-                            template:
-                              description: Template describes the pods that will be created.
-                              x-kubernetes-preserve-unknown-fields: true
-                            updateStrategy:
-                              description: UpdateStrategy indicates the UpdateStrategy that will be employed to update Pods in the CloneSet when a revision is made to Template.
-                              properties:
-                                inPlaceUpdateStrategy:
-                                  description: InPlaceUpdateStrategy contains strategies for in-place update.
-                                  properties:
-                                    gracePeriodSeconds:
-                                      description: GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec when in-place update a Pod.
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                maxSurge:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  description: 'The maximum number of pods that can be scheduled above the desired replicas during update or specified delete. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. Defaults to 0.'
-                                  x-kubernetes-int-or-string: true
-                                maxUnavailable:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  description: 'The maximum number of pods that can be unavailable during update or scale. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up by default. When maxSurge > 0, absolute number is calculated from percentage by rounding down. Defaults to 20%.'
-                                  x-kubernetes-int-or-string: true
-                                partition:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  description: 'Partition is the desired number of pods in old revisions. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up by default. It means when partition is set during pods updating, (replicas - partition value) number of pods will be updated. Default value is 0.'
-                                  x-kubernetes-int-or-string: true
-                                paused:
-                                  description: Paused indicates that the CloneSet is paused. Default value is false
-                                  type: boolean
-                                priorityStrategy:
-                                  description: Priorities are the rules for calculating the priority of updating pods. Each pod to be updated, will pass through these terms and get a sum of weights.
-                                  properties:
-                                    orderPriority:
-                                      description: 'Order priority terms, pods will be sorted by the value of orderedKey. For example: ``` orderPriority: - orderedKey: key1 - orderedKey: key2 ``` First, all pods which have key1 in labels will be sorted by the value of key1. Then, the left pods which have no key1 but have key2 in labels will be sorted by the value of key2 and put behind those pods have key1.'
-                                      items:
-                                        description: UpdatePriorityOrderTerm defines order priority.
-                                        properties:
-                                          orderedKey:
-                                            description: Calculate priority by value of this key. Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value, such as getting 5 in value '5', getting 10 in value 'sts-10'.
-                                            type: string
-                                        required:
-                                          - orderedKey
-                                        type: object
-                                      type: array
-                                    weightPriority:
-                                      description: Weight priority terms, pods will be sorted by the sum of all terms weight.
-                                      items:
-                                        description: UpdatePriorityWeightTerm defines weight priority.
-                                        properties:
-                                          matchSelector:
-                                            description: MatchSelector is used to select by pod's labels.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          weight:
-                                            description: Weight associated with matching the corresponding matchExpressions, in the range 1-100.
-                                            format: int32
-                                            type: integer
-                                        required:
-                                          - matchSelector
-                                          - weight
-                                        type: object
-                                      type: array
-                                  type: object
-                                scatterStrategy:
-                                  description: ScatterStrategy defines the scatter rules to make pods been scattered when update. This will avoid pods with the same key-value to be updated in one batch. - Note that pods will be scattered after priority sort. So, although priority strategy and scatter strategy can be applied together, we suggest to use either one of them. - If scatterStrategy is used, we suggest to just use one term. Otherwise, the update order can be hard to understand.
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - key
-                                      - value
-                                    type: object
-                                  type: array
-                                type:
-                                  description: Type indicates the type of the CloneSetUpdateStrategy. Default is ReCreate.
-                                  type: string
-                              type: object
-                            volumeClaimTemplates:
-                              description: VolumeClaimTemplates is a list of claims that pods are allowed to reference. Note that PVC will be deleted when its pod has been deleted.
-                              x-kubernetes-preserve-unknown-fields: true
-                          required:
-                            - selector
-                            - template
-                          type: object
-                      required:
-                        - spec
-                      type: object
-                    deploymentTemplate:
-                      description: Deployment template
-                      properties:
-                        metadata:
-                          x-kubernetes-preserve-unknown-fields: true
-                        spec:
-                          x-kubernetes-preserve-unknown-fields: true
-                      required:
-                        - spec
-                      type: object
-                    statefulSetTemplate:
-                      description: StatefulSet template
-                      properties:
-                        metadata:
-                          x-kubernetes-preserve-unknown-fields: true
-                        spec:
-                          x-kubernetes-preserve-unknown-fields: true
-                      required:
-                        - spec
-                      type: object
-                  type: object
-                topology:
-                  description: Topology describes the pods distribution detail between each of subsets.
-                  properties:
-                    subsets:
-                      description: Contains the details of each subset. Each element in this array represents one subset which will be provisioned and managed by UnitedDeployment.
-                      items:
-                        description: Subset defines the detail of a subset.
-                        properties:
-                          name:
-                            description: Indicates subset name as a DNS_LABEL, which will be used to generate subset workload name prefix in the format '<deployment-name>-<subset-name>-'. Name should be unique between all of the subsets under one UnitedDeployment.
-                            type: string
-                          nodeSelectorTerm:
-                            description: Indicates the node selector to form the subset. Depending on the node selector, pods provisioned could be distributed across multiple groups of nodes. A subset's nodeSelectorTerm is not allowed to be updated.
+                          lifecycle:
+                            description: Lifecycle defines the lifecycle hooks for Pods pre-delete, in-place update.
                             properties:
-                              matchExpressions:
-                                description: A list of node selector requirements by node's labels.
-                                items:
-                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector applies to.
+                              inPlaceUpdate:
+                                description: InPlaceUpdate is the hook before Pod to update and after Pod has been updated.
+                                properties:
+                                  finalizersHandler:
+                                    items:
                                       type: string
-                                    operator:
-                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
                                       type: string
-                                    values:
-                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
-                              matchFields:
-                                description: A list of node selector requirements by node's fields.
-                                items:
-                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                  properties:
-                                    key:
-                                      description: The label key that the selector applies to.
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
+                                    type: boolean
+                                type: object
+                              preDelete:
+                                description: PreDelete is the hook before Pod to be deleted.
+                                properties:
+                                  finalizersHandler:
+                                    items:
                                       type: string
-                                    operator:
-                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
                                       type: string
-                                    values:
-                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
+                                    type: boolean
+                                type: object
+                              preNormal:
+                                description: PreNormal is the hook after Pod to be created and ready to be Normal.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
+                                    type: boolean
+                                type: object
                             type: object
-                          patch:
-                            description: Patch indicates patching to the templateSpec. Patch takes precedence over other fields If the Patch also modifies the Replicas, NodeSelectorTerm or Tolerations, use value in the Patch
-                            x-kubernetes-preserve-unknown-fields: true
+                          persistentVolumeClaimRetentionPolicy:
+                            description: PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates. This requires the StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.
+                            properties:
+                              whenDeleted:
+                                description: WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted. The default policy of `Retain` causes PVCs to not be affected by StatefulSet deletion. The `Delete` policy causes those PVCs to be deleted.
+                                type: string
+                              whenScaled:
+                                description: WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down. The default policy of `Retain` causes PVCs to not be affected by a scaledown. The `Delete` policy causes the associated PVCs for any excess pods above the replica count to be deleted.
+                                type: string
+                            type: object
+                          podManagementPolicy:
+                            description: podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+                            type: string
                           replicas:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            description: Indicates the number of the pod to be created under this subset. Replicas could also be percentage like '10%', which means 10% of UnitedDeployment replicas of pods will be distributed under this subset. If nil, the number of replicas in this subset is determined by controller. Controller will try to keep all the subsets with nil replicas have average pods.
-                            x-kubernetes-int-or-string: true
-                          tolerations:
-                            description: Indicates the tolerations the pods under this subset have. A subset's tolerations is not allowed to be updated.
-                            items:
-                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
-                              properties:
-                                effect:
-                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                  type: string
-                                key:
-                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                  type: string
-                                operator:
-                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-                                  type: string
-                                tolerationSeconds:
-                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-                                  format: int64
-                                  type: integer
-                                value:
-                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                  type: string
-                              type: object
-                            type: array
-                        required:
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                updateStrategy:
-                  description: UpdateStrategy indicates the strategy the UnitedDeployment use to preform the update, when template is changed.
-                  properties:
-                    manualUpdate:
-                      description: Includes all of the parameters a Manual update strategy needs.
-                      properties:
-                        partitions:
-                          additionalProperties:
+                            description: 'replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1. TODO: Consider a rename of this field.'
                             format: int32
                             type: integer
-                          description: Indicates number of subset partition.
-                          type: object
-                      type: object
-                    type:
-                      description: Type of UnitedDeployment update strategy. Default is Manual.
-                      type: string
-                  type: object
-              required:
-                - selector
-              type: object
-            status:
-              description: UnitedDeploymentStatus defines the observed state of UnitedDeployment.
-              properties:
-                collisionCount:
-                  description: Count of hash collisions for the UnitedDeployment. The UnitedDeployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
-                  format: int32
-                  type: integer
-                conditions:
-                  description: Represents the latest available observations of a UnitedDeployment's current state.
-                  items:
-                    description: UnitedDeploymentCondition describes current state of a UnitedDeployment.
-                    properties:
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: A human readable message indicating details about the transition.
-                        type: string
-                      reason:
-                        description: The reason for the condition's last transition.
-                        type: string
-                      status:
-                        description: Status of the condition, one of True, False, Unknown.
-                        type: string
-                      type:
-                        description: Type of in place set condition.
-                        type: string
+                          reserveOrdinals:
+                            description: 'reserveOrdinals controls the ordinal numbers that should be reserved, and the replicas will always be the expectation number of running Pods. For a sts with replicas=3 and its Pods in [0, 1, 2]: - If you want to migrate Pod-1 and reserve this ordinal, just set spec.reserveOrdinal to [1]. Then controller will delete Pod-1 and create Pod-3 (existing Pods will be [0, 2, 3]) - If you just want to delete Pod-1, you should set spec.reserveOrdinal to [1] and spec.replicas to 2. Then controller will delete Pod-1 (existing Pods will be [0, 2])'
+                            items:
+                              type: integer
+                            type: array
+                          revisionHistoryLimit:
+                            description: revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
+                            format: int32
+                            type: integer
+                          scaleStrategy:
+                            description: scaleStrategy indicates the StatefulSetScaleStrategy that will be employed to scale Pods in the StatefulSet.
+                            properties:
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can be unavailable during scaling. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. It can just be allowed to work with Parallel podManagementPolicy.'
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          selector:
+                            description: 'selector is a label query over pods that should match the replica count. It must match the pod template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          serviceName:
+                            description: 'serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.'
+                            type: string
+                          template:
+                            description: template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
+                            x-kubernetes-preserve-unknown-fields: true
+                          updateStrategy:
+                            description: updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+                            properties:
+                              rollingUpdate:
+                                description: RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+                                properties:
+                                  inPlaceUpdateStrategy:
+                                    description: InPlaceUpdateStrategy contains strategies for in-place update.
+                                    properties:
+                                      gracePeriodSeconds:
+                                        description: GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec when in-place update a Pod.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. Also, maxUnavailable can just be allowed to work with Parallel podManagementPolicy. Defaults to 1.'
+                                    x-kubernetes-int-or-string: true
+                                  minReadySeconds:
+                                    description: MinReadySeconds indicates how long will the pod be considered ready after it's updated. MinReadySeconds works with both OrderedReady and Parallel podManagementPolicy. It affects the pod scale up speed when the podManagementPolicy is set to be OrderedReady. Combined with MaxUnavailable, it affects the pod update speed regardless of podManagementPolicy. Default value is 0, max is 300.
+                                    format: int32
+                                    type: integer
+                                  partition:
+                                    description: 'Partition indicates the ordinal at which the StatefulSet should be partitioned by default. But if unorderedUpdate has been set: - Partition indicates the number of pods with non-updated revisions when rolling update. - It means controller will update $(replicas - partition) number of pod. Default value is 0.'
+                                    format: int32
+                                    type: integer
+                                  paused:
+                                    description: Paused indicates that the StatefulSet is paused. Default value is false
+                                    type: boolean
+                                  podUpdatePolicy:
+                                    description: PodUpdatePolicy indicates how pods should be updated Default value is "ReCreate"
+                                    type: string
+                                  unorderedUpdate:
+                                    description: UnorderedUpdate contains strategies for non-ordered update. If it is not nil, pods will be updated with non-ordered sequence. Noted that UnorderedUpdate can only be allowed to work with Parallel podManagementPolicy
+                                    properties:
+                                      priorityStrategy:
+                                        description: Priorities are the rules for calculating the priority of updating pods. Each pod to be updated, will pass through these terms and get a sum of weights.
+                                        properties:
+                                          orderPriority:
+                                            description: 'Order priority terms, pods will be sorted by the value of orderedKey. For example: ``` orderPriority: - orderedKey: key1 - orderedKey: key2 ``` First, all pods which have key1 in labels will be sorted by the value of key1. Then, the left pods which have no key1 but have key2 in labels will be sorted by the value of key2 and put behind those pods have key1.'
+                                            items:
+                                              description: UpdatePriorityOrderTerm defines order priority.
+                                              properties:
+                                                orderedKey:
+                                                  description: Calculate priority by value of this key. Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value, such as getting 5 in value '5', getting 10 in value 'sts-10'.
+                                                  type: string
+                                              required:
+                                              - orderedKey
+                                              type: object
+                                            type: array
+                                          weightPriority:
+                                            description: Weight priority terms, pods will be sorted by the sum of all terms weight.
+                                            items:
+                                              description: UpdatePriorityWeightTerm defines weight priority.
+                                              properties:
+                                                matchSelector:
+                                                  description: MatchSelector is used to select by pod's labels.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                      items:
+                                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the label key that the selector applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                weight:
+                                                  description: Weight associated with matching the corresponding matchExpressions, in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - matchSelector
+                                              - weight
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                type: object
+                              type:
+                                description: Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+                                type: string
+                            type: object
+                          volumeClaimTemplates:
+                            description: 'volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name. TODO: Define the behavior if a claim already exists with the same name.'
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - selector
+                        - template
+                        type: object
+                    required:
+                    - spec
                     type: object
-                  type: array
-                currentRevision:
-                  description: CurrentRevision, if not empty, indicates the current version of the UnitedDeployment.
-                  type: string
-                labelSelector:
-                  description: LabelSelector is label selectors for query over pods that should match the replica count used by HPA.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed for this UnitedDeployment. It corresponds to the UnitedDeployment's generation, which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-                readyReplicas:
-                  description: The number of ready replicas.
-                  format: int32
-                  type: integer
-                replicas:
-                  description: Replicas is the most recently observed number of replicas.
-                  format: int32
-                  type: integer
-                subsetReplicas:
-                  additionalProperties:
-                    format: int32
-                    type: integer
-                  description: Records the topology detail information of the replicas of each subset.
-                  type: object
-                updateStatus:
-                  description: Records the information of update progress.
-                  properties:
-                    currentPartitions:
-                      additionalProperties:
-                        format: int32
-                        type: integer
-                      description: Records the current partition.
+                  cloneSetTemplate:
+                    description: CloneSet template
+                    properties:
+                      metadata:
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        description: CloneSetSpec defines the desired state of CloneSet
+                        properties:
+                          lifecycle:
+                            description: Lifecycle defines the lifecycle hooks for Pods pre-available(pre-normal), pre-delete, in-place update.
+                            properties:
+                              inPlaceUpdate:
+                                description: InPlaceUpdate is the hook before Pod to update and after Pod has been updated.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
+                                    type: boolean
+                                type: object
+                              preDelete:
+                                description: PreDelete is the hook before Pod to be deleted.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
+                                    type: boolean
+                                type: object
+                              preNormal:
+                                description: PreNormal is the hook after Pod to be created and ready to be Normal.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: - Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate state. - Pod will be restored to ''Ready'' at Updated state if it was set to ''NotReady'' at preparingUpdate state. Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook. Default to false.'
+                                    type: boolean
+                                type: object
+                            type: object
+                          minReadySeconds:
+                            description: Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+                            format: int32
+                            type: integer
+                          replicas:
+                            description: Replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template. If unspecified, defaults to 1.
+                            format: int32
+                            type: integer
+                          revisionHistoryLimit:
+                            description: RevisionHistoryLimit is the maximum number of revisions that will be maintained in the CloneSet's revision history. The revision history consists of all revisions not represented by a currently applied CloneSetSpec version. The default value is 10.
+                            format: int32
+                            type: integer
+                          scaleStrategy:
+                            description: ScaleStrategy indicates the ScaleStrategy that will be employed to create and delete Pods in the CloneSet.
+                            properties:
+                              disablePVCReuse:
+                                description: Indicate if cloneSet will reuse already existed pvc to rebuild a new pod
+                                type: boolean
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The maximum number of pods that can be unavailable for scaled pods. This field can control the changes rate of replicas for CloneSet so as to minimize the impact for users' service. The scale will fail if the number of unavailable pods were greater than this MaxUnavailable at scaling up. MaxUnavailable works only when scaling up.
+                                x-kubernetes-int-or-string: true
+                              podsToDelete:
+                                description: PodsToDelete is the names of Pod should be deleted. Note that this list will be truncated for non-existing pod names.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          selector:
+                            description: 'Selector is a label query over pods that should match the replica count. It must match the pod template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          template:
+                            description: Template describes the pods that will be created.
+                            x-kubernetes-preserve-unknown-fields: true
+                          updateStrategy:
+                            description: UpdateStrategy indicates the UpdateStrategy that will be employed to update Pods in the CloneSet when a revision is made to Template.
+                            properties:
+                              inPlaceUpdateStrategy:
+                                description: InPlaceUpdateStrategy contains strategies for in-place update.
+                                properties:
+                                  gracePeriodSeconds:
+                                    description: GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec when in-place update a Pod.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can be scheduled above the desired replicas during update or specified delete. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. Defaults to 0.'
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can be unavailable during update or scale. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up by default. When maxSurge > 0, absolute number is calculated from percentage by rounding down. Defaults to 20%.'
+                                x-kubernetes-int-or-string: true
+                              partition:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'Partition is the desired number of pods in old revisions. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up by default. It means when partition is set during pods updating, (replicas - partition value) number of pods will be updated. Default value is 0.'
+                                x-kubernetes-int-or-string: true
+                              paused:
+                                description: Paused indicates that the CloneSet is paused. Default value is false
+                                type: boolean
+                              priorityStrategy:
+                                description: Priorities are the rules for calculating the priority of updating pods. Each pod to be updated, will pass through these terms and get a sum of weights.
+                                properties:
+                                  orderPriority:
+                                    description: 'Order priority terms, pods will be sorted by the value of orderedKey. For example: ``` orderPriority: - orderedKey: key1 - orderedKey: key2 ``` First, all pods which have key1 in labels will be sorted by the value of key1. Then, the left pods which have no key1 but have key2 in labels will be sorted by the value of key2 and put behind those pods have key1.'
+                                    items:
+                                      description: UpdatePriorityOrderTerm defines order priority.
+                                      properties:
+                                        orderedKey:
+                                          description: Calculate priority by value of this key. Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value, such as getting 5 in value '5', getting 10 in value 'sts-10'.
+                                          type: string
+                                      required:
+                                      - orderedKey
+                                      type: object
+                                    type: array
+                                  weightPriority:
+                                    description: Weight priority terms, pods will be sorted by the sum of all terms weight.
+                                    items:
+                                      description: UpdatePriorityWeightTerm defines weight priority.
+                                      properties:
+                                        matchSelector:
+                                          description: MatchSelector is used to select by pod's labels.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        weight:
+                                          description: Weight associated with matching the corresponding matchExpressions, in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - matchSelector
+                                      - weight
+                                      type: object
+                                    type: array
+                                type: object
+                              scatterStrategy:
+                                description: ScatterStrategy defines the scatter rules to make pods been scattered when update. This will avoid pods with the same key-value to be updated in one batch. - Note that pods will be scattered after priority sort. So, although priority strategy and scatter strategy can be applied together, we suggest to use either one of them. - If scatterStrategy is used, we suggest to just use one term. Otherwise, the update order can be hard to understand.
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                type: array
+                              type:
+                                description: Type indicates the type of the CloneSetUpdateStrategy. Default is ReCreate.
+                                type: string
+                            type: object
+                          volumeClaimTemplates:
+                            description: VolumeClaimTemplates is a list of claims that pods are allowed to reference. Note that PVC will be deleted when its pod has been deleted.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - selector
+                        - template
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                  deploymentTemplate:
+                    description: Deployment template
+                    properties:
+                      metadata:
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - spec
+                    type: object
+                  statefulSetTemplate:
+                    description: StatefulSet template
+                    properties:
+                      metadata:
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - spec
+                    type: object
+                type: object
+              topology:
+                description: Topology describes the pods distribution detail between each of subsets.
+                properties:
+                  subsets:
+                    description: Contains the details of each subset. Each element in this array represents one subset which will be provisioned and managed by UnitedDeployment.
+                    items:
+                      description: Subset defines the detail of a subset.
+                      properties:
+                        maxReplicas:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Indicates the upper bounded replicas of the subset. MaxReplicas must be more than or equal to MinReplicas. MaxReplicas == nil means no limitation. Please ensure that at least one subset has empty MaxReplicas(no limitation) to avoid stuck scaling. Defaults to nil.
+                          x-kubernetes-int-or-string: true
+                        minReplicas:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Indicates the lower bounded replicas of the subset. MinReplicas must be more than or equal to 0 if it is set. Controller will prioritize satisfy minReplicas for each subset according to the order of Topology.Subsets. Defaults to 0.
+                          x-kubernetes-int-or-string: true
+                        name:
+                          description: Indicates subset name as a DNS_LABEL, which will be used to generate subset workload name prefix in the format '<deployment-name>-<subset-name>-'. Name should be unique between all of the subsets under one UnitedDeployment.
+                          type: string
+                        nodeSelectorTerm:
+                          description: Indicates the node selector to form the subset. Depending on the node selector, pods provisioned could be distributed across multiple groups of nodes. A subset's nodeSelectorTerm is not allowed to be updated.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by node's labels.
+                              items:
+                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by node's fields.
+                              items:
+                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        patch:
+                          description: Patch indicates patching to the templateSpec. Patch takes precedence over other fields If the Patch also modifies the Replicas, NodeSelectorTerm or Tolerations, use value in the Patch
+                          x-kubernetes-preserve-unknown-fields: true
+                        replicas:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Indicates the number of the pod to be created under this subset. Replicas could also be percentage like '10%', which means 10% of UnitedDeployment replicas of pods will be distributed under this subset. If nil, the number of replicas in this subset is determined by controller. Controller will try to keep all the subsets with nil replicas have average pods. Replicas and MinReplicas/MaxReplicas are mutually exclusive in a UnitedDeployment.
+                          x-kubernetes-int-or-string: true
+                        tolerations:
+                          description: Indicates the tolerations the pods under this subset have. A subset's tolerations is not allowed to be updated.
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - name
                       type: object
-                    updatedRevision:
-                      description: Records the latest revision.
+                    type: array
+                type: object
+              updateStrategy:
+                description: UpdateStrategy indicates the strategy the UnitedDeployment use to preform the update, when template is changed.
+                properties:
+                  manualUpdate:
+                    description: Includes all of the parameters a Manual update strategy needs.
+                    properties:
+                      partitions:
+                        additionalProperties:
+                          format: int32
+                          type: integer
+                        description: Indicates number of subset partition.
+                        type: object
+                    type: object
+                  type:
+                    description: Type of UnitedDeployment update strategy. Default is Manual.
+                    type: string
+                type: object
+            required:
+            - selector
+            type: object
+          status:
+            description: UnitedDeploymentStatus defines the observed state of UnitedDeployment.
+            properties:
+              collisionCount:
+                description: Count of hash collisions for the UnitedDeployment. The UnitedDeployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a UnitedDeployment's current state.
+                items:
+                  description: UnitedDeploymentCondition describes current state of a UnitedDeployment.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of in place set condition.
                       type: string
                   type: object
-                updatedReadyReplicas:
-                  description: The number of ready current revision replicas for this UnitedDeployment.
+                type: array
+              currentRevision:
+                description: CurrentRevision, if not empty, indicates the current version of the UnitedDeployment.
+                type: string
+              labelSelector:
+                description: LabelSelector is label selectors for query over pods that should match the replica count used by HPA.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed for this UnitedDeployment. It corresponds to the UnitedDeployment's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              subsetReplicas:
+                additionalProperties:
                   format: int32
                   type: integer
-                updatedReplicas:
-                  description: The number of pods in current version.
-                  format: int32
-                  type: integer
-              required:
-                - currentRevision
-                - replicas
-                - updatedReplicas
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        scale:
-          labelSelectorPath: .status.labelSelector
-          specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.replicas
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                description: Records the topology detail information of the replicas of each subset.
+                type: object
+              updateStatus:
+                description: Records the information of update progress.
+                properties:
+                  currentPartitions:
+                    additionalProperties:
+                      format: int32
+                      type: integer
+                    description: Records the current partition.
+                    type: object
+                  updatedRevision:
+                    description: Records the latest revision.
+                    type: string
+                type: object
+              updatedReadyReplicas:
+                description: The number of ready current revision replicas for this UnitedDeployment.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: The number of pods in current version.
+                format: int32
+                type: integer
+            required:
+            - currentRevision
+            - replicas
+            - updatedReplicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.labelSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
 {{- end }}

--- a/versions/kruise/1.5.1/templates/manager.yaml
+++ b/versions/kruise/1.5.1/templates/manager.yaml
@@ -188,6 +188,12 @@ spec:
         - --addr=:{{ .Values.daemon.port }}
         - --feature-gates={{ .Values.featureGates }}
         - --socket-file={{ .Values.daemon.socketFile }}
+{{- if not .Values.daemon.enablePprof }}
+        - --enable-pprof=false
+{{- else }}
+        - --enable-pprof=true
+        - --pprof-addr={{ .Values.daemon.pprofAddr }}
+{{- end }}
         image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}
         imagePullPolicy: Always
         name: daemon

--- a/versions/kruise/1.5.1/values.yaml
+++ b/versions/kruise/1.5.1/values.yaml
@@ -24,7 +24,7 @@ manager:
   replicas: 2
   image:
     repository: openkruise/kruise-manager
-    tag: v1.5.0
+    tag: v1.5.1
   webhook:
     port: 9876
   metrics:
@@ -61,6 +61,7 @@ daemon:
     level: "4"
 
   port: 10221
+  enablePprof: true
   pprofAddr: "localhost:10222"
 
   socketLocation: "/var/run"


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
