### PR TITLE
Change DNS policy of kruise-daemon to ClusterFirstWithHostNet to fix …

### DIFF
--- a/versions/kruise/1.5.1/templates/manager.yaml
+++ b/versions/kruise/1.5.1/templates/manager.yaml
@@ -229,6 +229,7 @@ spec:
       tolerations:
       - operator: Exists
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       terminationGracePeriodSeconds: 10
       serviceAccountName: kruise-daemon
       volumes:


### PR DESCRIPTION
[BUG] kruise-daemon should use ClusterFirstWithHostNet for the DNS Policy #1447  
https://github.com/openkruise/kruise/issues/1447
  
Change DNS policy of kruise-daemon to ClusterFirstWithHostNet to fix the bug.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
