### PR TITLE
add kube-state-metric 0.2 chart

### DIFF
--- a/charts/kruise-state-metrics
+++ b/charts/kruise-state-metrics
@@ -1,1 +1,1 @@
-../versions/kruise-state-metrics/0.1
+../versions/kruise-state-metrics/0.2

--- a/versions/kruise-state-metrics/0.2/.helmignore
+++ b/versions/kruise-state-metrics/0.2/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/versions/kruise-state-metrics/0.2/Chart.yaml
+++ b/versions/kruise-state-metrics/0.2/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: kruise-state-metrics
+description: Install kruise-state-metrics to generate and expose kruise metrics
+type: application
+version: 0.2.0
+appVersion: "1.16.0"
+icon: https://openkruise.io/img/logo_white.png
+keywords:
+  - metric
+  - monitoring
+  - prometheus
+  - kubernetes
+  - openkruise
+  - workload
+home: https://openkruise.io
+sources:
+  - https://github.com/openkruise/kruise-state-metrics

--- a/versions/kruise-state-metrics/0.2/templates/_helpers.tpl
+++ b/versions/kruise-state-metrics/0.2/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kruise-state-metrics.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kruise-state-metrics.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kruise-state-metrics.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kruise-state-metrics.labels" -}}
+control-plane: {{ .Values.fullnameOverride }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kruise-state-metrics.selectorLabels" -}}
+control-plane: {{ .Values.fullnameOverride }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kruise-state-metrics.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kruise-state-metrics.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/versions/kruise-state-metrics/0.2/templates/deployment.yaml
+++ b/versions/kruise-state-metrics/0.2/templates/deployment.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.installation.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+  {{- include "kruise-state-metrics.labels" . | nindent 4 }}
+  name: {{ .Values.installation.namespace }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kruise-state-metrics.fullname" . }}
+  namespace: {{ .Values.installation.namespace }}
+  labels:
+    {{- include "kruise-state-metrics.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kruise-state-metrics.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "kruise-state-metrics.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kruise-state-metrics.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          command:
+          - /kruise-state-metrics
+          args:
+            - --logtostderr=true
+            - --v=5
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - name: http-metrics
+            containerPort: 8080
+          - name: telemetry
+            containerPort: 8081
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8081
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/versions/kruise-state-metrics/0.2/templates/service.yaml
+++ b/versions/kruise-state-metrics/0.2/templates/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kruise-state-metrics.fullname" . }}
+  namespace: {{ .Values.installation.namespace }}
+  labels:
+    {{- include "kruise-state-metrics.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http-metrics
+      port: 8080
+      targetPort: http-metrics
+    - name: telemetry
+      port: 8081
+      targetPort: telemetry
+  selector:
+    {{- include "kruise-state-metrics.selectorLabels" . | nindent 4 }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kruise-state-metrics.fullname" . }}
+  namespace: {{ .Values.installation.namespace }}
+  labels:
+    {{- include "kruise-state-metrics.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kruise-state-metrics.labels" . | nindent 6 }}
+  endpoints:
+    - port: http-metrics

--- a/versions/kruise-state-metrics/0.2/templates/serviceaccount.yaml
+++ b/versions/kruise-state-metrics/0.2/templates/serviceaccount.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kruise-state-metrics-role
+rules:
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kruise-state-metrics-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kruise-state-metrics-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kruise-state-metrics.serviceAccountName" . }}
+    namespace: {{ .Values.installation.namespace }}
+---
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kruise-state-metrics.serviceAccountName" . }}
+  namespace: {{ .Values.installation.namespace }}
+  labels:
+    {{- include "kruise-state-metrics.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/versions/kruise-state-metrics/0.2/values.yaml
+++ b/versions/kruise-state-metrics/0.2/values.yaml
@@ -1,0 +1,57 @@
+# Default values for kruise-state-metrics.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+installation:
+  namespace: kruise-system
+  createNamespace: false
+
+replicaCount: 1
+
+image:
+  repository: openkruise/kruise-state-metrics
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0.2.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: "kruise-state-metrics"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+service:
+  type: ClusterIP
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 100Mi
+  requests:
+    cpu: 100m
+    memory: 100Mi
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
