### PR TITLE
feat: Exclude kube-system by default in webhooks during installation

### DIFF
--- a/versions/kruise/1.5.2/Chart.yaml
+++ b/versions/kruise/1.5.2/Chart.yaml
@@ -22,3 +22,4 @@ annotations:
   artifacthub.io/changes: |
     - "[Changed]: https://github.com/openkruise/kruise/blob/master/CHANGELOG.md"
     - "[Changed]: Support extra environment variables in the manager DaemonSet"
+    - "[Changed]: Support exclude specified namespaces from webhook"

--- a/versions/kruise/1.5.2/templates/webhookconfiguration.yaml
+++ b/versions/kruise/1.5.2/templates/webhookconfiguration.yaml
@@ -19,6 +19,10 @@ webhooks:
           operator: NotIn
           values:
             - openkruise
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - ""
@@ -281,6 +285,12 @@ webhooks:
       matchExpressions:
         - key: policy.kruise.io/delete-protection
           operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - apps
@@ -305,6 +315,12 @@ webhooks:
       matchExpressions:
         - key: policy.kruise.io/delete-protection
           operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - apps
@@ -329,6 +345,12 @@ webhooks:
       matchExpressions:
         - key: policy.kruise.io/delete-protection
           operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - apps
@@ -353,6 +375,12 @@ webhooks:
       matchExpressions:
         - key: policy.kruise.io/delete-protection
           operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - apiextensions.k8s.io
@@ -378,6 +406,12 @@ webhooks:
       matchExpressions:
         - key: policy.kruise.io/delete-protection
           operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - ""
@@ -404,6 +438,10 @@ webhooks:
           operator: NotIn
           values:
             - openkruise
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - ""
@@ -431,6 +469,10 @@ webhooks:
           operator: NotIn
           values:
             - openkruise
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
     rules:
       - apiGroups:
           - ""


### PR DESCRIPTION
Exclude specified namespaces from webhooks.
Fix https://github.com/openkruise/kruise/issues/1472

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
