### PR TITLE
change kruise daemon dns policy to ClusterFirstWithHostNet

### DIFF
--- a/versions/kruise/1.7.0-alpha.1/templates/manager.yaml
+++ b/versions/kruise/1.7.0-alpha.1/templates/manager.yaml
@@ -258,6 +258,7 @@ spec:
       tolerations:
       - operator: Exists
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       terminationGracePeriodSeconds: 10
       serviceAccountName: kruise-daemon
       volumes:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [✅] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [✅] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [✅] Any new values are backwards compatible and/or have sensible default.
* [✅] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.

change kruise daemon dns policy to ClusterFirstWithHostNet to fix [kruise issue#1447](https://github.com/openkruise/kruise/issues/1447)