### PR TITLE
make kruise deployment spread across availability zone

### DIFF
--- a/versions/kruise-game/0.9/templates/manager.yaml
+++ b/versions/kruise-game/0.9/templates/manager.yaml
@@ -98,6 +98,15 @@ spec:
           volumeMounts:
             - mountPath: /etc/kruise-game
               name: provider-config
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            control-plane: {{ .Values.kruiseGame.fullname }}
+        matchLabelKeys:
+        - pod-template-hash
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable:  ScheduleAnyway
       serviceAccountName: {{ .Values.kruiseGame.fullname }}
       terminationGracePeriodSeconds: 10
       volumes:

--- a/versions/kruise-rollout/0.5/templates/manager.yaml
+++ b/versions/kruise-rollout/0.5/templates/manager.yaml
@@ -96,6 +96,15 @@ spec:
                         - {{ .Values.rollout.fullname }}
                 topologyKey: kubernetes.io/hostname
               weight: 100
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            control-plane: {{ .Values.rollout.fullname }}
+        matchLabelKeys:
+        - pod-template-hash
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable:  ScheduleAnyway
       {{- with .Values.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}

--- a/versions/kruise-state-metrics/0.2/templates/deployment.yaml
+++ b/versions/kruise-state-metrics/0.2/templates/deployment.yaml
@@ -57,6 +57,15 @@ spec:
               port: 8081
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+          {{- include "kruise-state-metrics.selectorLabels" . | nindent 12 }}
+        matchLabelKeys:
+        - pod-template-hash
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable:  ScheduleAnyway
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/versions/kruise/1.7.2/templates/manager.yaml
+++ b/versions/kruise/1.7.2/templates/manager.yaml
@@ -124,6 +124,15 @@ spec:
                   - controller-manager
               topologyKey: kubernetes.io/hostname
             weight: 100
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            control-plane: controller-manager
+        matchLabelKeys:
+        - pod-template-hash
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable:  ScheduleAnyway
 {{- with .Values.manager.nodeAffinity }}
         nodeAffinity:
 {{ toYaml . | indent 10 }}


### PR DESCRIPTION
update the latest chart to add topologyspread over availability zone
