### PR TITLE
Add aggregate role

### DIFF
--- a/versions/kruise/1.8.0/Chart.yaml
+++ b/versions/kruise/1.8.0/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kruise
 description: Helm chart for kruise components
-version: 1.8.0
+version: 1.8.1
 appVersion: 1.8.0
 kubeVersion: ">= 1.18.0-0"
 icon: https://openkruise.io/img/openkruise-logo-bg.jpg

--- a/versions/kruise/1.8.0/templates/rbac_role.yaml
+++ b/versions/kruise/1.8.0/templates/rbac_role.yaml
@@ -962,12 +962,41 @@ metadata:
 rules:
 - apiGroups: ["apps.kruise.io"]
   resources:
-  - clonesets
-  - clonesets/scale
-  - clonesets/status
-  - statefulsets
-  - statefulsets/scale
-  - statefulsets/status
+    - advancedcronjobs
+    - advancedcronjobs/status
+    - broadcastjobs
+    - broadcastjobs/status
+    - clonesets
+    - clonesets/scale
+    - clonesets/status
+    - containerrecreaterequests
+    - containerrecreaterequests/status
+    - daemonsets
+    - daemonsets/status
+    - imagelistpulljobs
+    - imagelistpulljobs/status
+    - imagepulljobs
+    - imagepulljobs/status
+    - nodeimages
+    - nodeimages/status
+    - nodepodprobes
+    - nodepodprobes/status
+    - persistentpodstates
+    - persistentpodstates/status
+    - podprobemarkers
+    - podprobemarkers/status
+    - resourcedistributions
+    - resourcedistributions/status
+    - sidecarsets
+    - sidecarsets/status
+    - statefulsets
+    - statefulsets/scale
+    - statefulsets/status
+    - uniteddeployments
+    - uniteddeployments/scale
+    - uniteddeployments/status
+    - workloadspreads
+    - workloadspreads/status
   verbs:
     - get
     - list
@@ -983,11 +1012,25 @@ metadata:
 rules:
 - apiGroups: ["apps.kruise.io"]
   resources:
-  - clonesets
-  - clonesets/scale
-  - clonesets/rollback
-  - statefulsets
-  - statefulsets/scale
+    - advancedcronjobs
+    - broadcastjobs
+    - clonesets
+    - clonesets/scale
+    - containerrecreaterequests
+    - daemonsets
+    - imagelistpulljobs
+    - imagepulljobs
+    - nodeimages
+    - nodepodprobes
+    - persistentpodstates
+    - podprobemarkers
+    - resourcedistributions
+    - sidecarsets
+    - statefulsets
+    - statefulsets/scale
+    - uniteddeployments
+    - uniteddeployments/scale
+    - workloadspreads
   verbs:
     - create
     - delete

--- a/versions/kruise/1.8.0/templates/rbac_role.yaml
+++ b/versions/kruise/1.8.0/templates/rbac_role.yaml
@@ -951,3 +951,46 @@ subjects:
 - kind: ServiceAccount
   name: kruise-daemon
   namespace: {{ .Values.installation.namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-kruise-view
+  labels:
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["apps.kruise.io"]
+  resources:
+  - clonesets
+  - clonesets/scale
+  - clonesets/status
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+    - get
+    - list
+    - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-kruise-edit
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["apps.kruise.io"]
+  resources:
+  - clonesets
+  - clonesets/scale
+  - clonesets/rollback
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update

--- a/versions/kruise/1.8.0/templates/rbac_role.yaml
+++ b/versions/kruise/1.8.0/templates/rbac_role.yaml
@@ -985,8 +985,6 @@ rules:
     - persistentpodstates/status
     - podprobemarkers
     - podprobemarkers/status
-    - resourcedistributions
-    - resourcedistributions/status
     - sidecarsets
     - sidecarsets/status
     - statefulsets
@@ -1024,7 +1022,6 @@ rules:
     - nodepodprobes
     - persistentpodstates
     - podprobemarkers
-    - resourcedistributions
     - sidecarsets
     - statefulsets
     - statefulsets/scale
@@ -1032,6 +1029,34 @@ rules:
     - uniteddeployments/scale
     - workloadspreads
   verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-kruise-admin
+  labels:
+    # Add these permissions to the "admin" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["apps.kruise.io"]
+  resources:
+    - resourcedistributions/status
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: ["apps.kruise.io"]
+  resources:
+    - resourcedistributions
+  verbs:
+    - get
+    - list
+    - watch
     - create
     - delete
     - deletecollection


### PR DESCRIPTION
在多租户场景，普通用户无法操纵cloneset/statefulset等对象，需要增加权限。

根据kubernetes RBAC规则，https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles，添加了aggregate-to-xxx 权限。

TODO：
- [x] 其他workload是否需要添加？