### PR TITLE
Fix namespace for kruise rollout webhook service

### DIFF
--- a/versions/kruise-rollout/0.5/templates/rollouts.kruise.io_batchreleases.yaml
+++ b/versions/kruise-rollout/0.5/templates/rollouts.kruise.io_batchreleases.yaml
@@ -11,7 +11,7 @@ spec:
       clientConfig:
         service:
           name: kruise-rollout-webhook-service
-          namespace: kruise-rollout
+          namespace: {{ .Values.installation.namespace }}
           path: /convert
       conversionReviewVersions:
       - v1beta1

--- a/versions/kruise-rollout/0.5/templates/rollouts.kruise.io_rollouts.yaml
+++ b/versions/kruise-rollout/0.5/templates/rollouts.kruise.io_rollouts.yaml
@@ -11,7 +11,7 @@ spec:
       clientConfig:
         service:
           name: kruise-rollout-webhook-service
-          namespace: kruise-rollout
+          namespace: {{ .Values.installation.namespace }}
           path: /convert
       conversionReviewVersions:
       - v1beta1

--- a/versions/kruise-rollout/0.6.0/templates/rollouts.kruise.io_batchreleases.yaml
+++ b/versions/kruise-rollout/0.6.0/templates/rollouts.kruise.io_batchreleases.yaml
@@ -11,7 +11,7 @@ spec:
       clientConfig:
         service:
           name: kruise-rollout-webhook-service
-          namespace: kruise-rollout
+          namespace: {{ .Values.installation.namespace }}
           path: /convert
       conversionReviewVersions:
       - v1beta1

--- a/versions/kruise-rollout/0.6.0/templates/rollouts.kruise.io_rollouts.yaml
+++ b/versions/kruise-rollout/0.6.0/templates/rollouts.kruise.io_rollouts.yaml
@@ -11,7 +11,7 @@ spec:
       clientConfig:
         service:
           name: kruise-rollout-webhook-service
-          namespace: kruise-rollout
+          namespace: {{ .Values.installation.namespace }}
           path: /convert
       conversionReviewVersions:
       - v1beta1


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
