### PR TITLE
bump ci ubuntu version to 24.04

### DIFF
--- a/.github/workflows/e2e-kruise.yaml
+++ b/.github/workflows/e2e-kruise.yaml
@@ -21,10 +21,10 @@ env:
 jobs:
   # 1.27-
   install-for-lower:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        kind-version: [ v1.18.20, v1.20.15, v1.24.6, v1.26.3 ]
+        kind-version: [ v1.20.15, v1.24.6, v1.26.3 ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -45,14 +45,14 @@ jobs:
       - name: install Kruise rollout
         if: ${{ ! startsWith(matrix.kind-version, 'v1.18') }}
         run: |
-            make install-kruise-rollout-from-local
+          make install-kruise-rollout-from-local
       - name: install Kruise game
         run: |
           make install-kruise-game-from-local
 
   # 1.27+
   install-for-higher:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         kind-version: [ v1.28.7, v1.30.8 ]


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
