### PR TITLE
Release: rollout chart v0.6.2

### DIFF
--- a/charts/kruise-rollout
+++ b/charts/kruise-rollout
@@ -1,1 +1,1 @@
-../versions/kruise-rollout/0.6.1
+../versions/kruise-rollout/0.6.2

--- a/versions/kruise-rollout/0.6.2/.helmignore
+++ b/versions/kruise-rollout/0.6.2/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/versions/kruise-rollout/0.6.2/Chart.yaml
+++ b/versions/kruise-rollout/0.6.2/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: kruise-rollout
+description: Helm chart for kruise-rollout components
+version: 0.6.1
+appVersion: 0.6.1
+kubeVersion: ">= 1.19.0-0"
+icon: https://openkruise.io/img/openkruise-logo-bg.jpg
+keywords:
+  - rollout
+home: https://openkruise.io
+sources:
+  - https://github.com/openkruise/rollouts

--- a/versions/kruise-rollout/0.6.2/Chart.yaml
+++ b/versions/kruise-rollout/0.6.2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kruise-rollout
 description: Helm chart for kruise-rollout components
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.6.1
 kubeVersion: ">= 1.19.0-0"
 icon: https://openkruise.io/img/openkruise-logo-bg.jpg

--- a/versions/kruise-rollout/0.6.2/README.md
+++ b/versions/kruise-rollout/0.6.2/README.md
@@ -1,0 +1,47 @@
+# Kruise Rollout v0.6.1
+
+## Configuration
+
+The following table lists the configurable parameters of the kruise chart and their default values.
+
+| Parameter                        | Description                                                       | Default                             |
+|----------------------------------|-------------------------------------------------------------------|-------------------------------------|
+| `installation.namespace`         | Namespace for kruise-rollout operation installation               | `kruise-rollout`                    |
+| `installation.createNamespace`   | Whether to create the installation.namespace                      | `true`                              |
+| `rollout.fullname`               | Nick name for kruise-rollout deployment and other configurations  | `kruise-rollout-controller-manager` |
+| `rollout.featureGates`           | Feature gates for kruise-rollout, empty string means all disabled | `AdvancedDeployment=true`           |
+| `rollout.healthBindPort`         | Port for checking health of kruise-rollout container              | `8081`                              |
+| `rollout.metricsBindAddr`        | Port of metrics served by kruise-rollout container                | `127.0.0.1:8080`                    |
+| `rollout.log.level`              | Log level that kruise-rollout printed                             | `4`                                 |
+| `rollout.webhook.port`           | Port of webhook served by kruise-rollout container                | `9876`                              |
+| `rollout.webhook.objectSelector` | ObjectSelector for workloads in MutatingWebhookConfigurations     | ` `                                 |
+| `image.repository`               | Repository for kruise-rollout image                               | `openkruise/kruise-rollout`         |
+| `image.tag`                      | Tag for kruise-rollout image                                      | `v0.6.1`                            |
+| `image.pullPolicy`               | ImagePullPolicy for kruise-rollout container                      | `Always`                            |
+| `imagePullSecrets`               | The list of image pull secrets for kruise-rollout image           | ` `                                 |
+| `resources.limits.cpu`           | CPU resource limit of kruise-rollout container                    | `500m`                              |
+| `resources.limits.memory`        | Memory resource limit of kruise-rollout container                 | `1Gi`                               |
+| `resources.requests.cpu`         | CPU resource request of kruise-rollout container                  | `100m`                              |
+| `resources.requests.memory`      | Memory resource request of kruise-rollout container               | `256Mi`                             |
+| `replicaCount`                   | Replicas of kruise-rollout deployment                             | `2`                                 |
+| `service.port`                   | Port of webhook served by kruise-rollout webhook service          | `443`                               |
+| `serviceAccount.annotations`     | The annotations for serviceAccount of kruise-rollout              | ` `                                 |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+### Optional: feature-gate
+
+Feature-gate controls some influential features in Kruise:
+
+| Name                  | Description                                                                                            | Default  | Effect (if closed)                      |
+|-----------------------|--------------------------------------------------------------------------------------------------------|----------|-----------------------------------------|
+| `AdvancedDeployment`  | Whether to enable the ability to rolling update deployment in batches without extra canary deployment  | `true`   | advanced deployment controller disabled |
+
+### Optional: the local image for China
+
+If you are in China and have problem to pull image from official DockerHub, you can use the registry hosted on Alibaba Cloud:
+
+```bash
+$ helm install kruise https://... --set image.repository=openkruise-registry.cn-shanghai.cr.aliyuncs.com/openkruise/kruise-rollout
+...
+```

--- a/versions/kruise-rollout/0.6.2/README.md
+++ b/versions/kruise-rollout/0.6.2/README.md
@@ -16,7 +16,7 @@ The following table lists the configurable parameters of the kruise chart and th
 | `rollout.webhook.port`           | Port of webhook served by kruise-rollout container                | `9876`                              |
 | `rollout.webhook.objectSelector` | ObjectSelector for workloads in MutatingWebhookConfigurations     | ` `                                 |
 | `image.repository`               | Repository for kruise-rollout image                               | `openkruise/kruise-rollout`         |
-| `image.tag`                      | Tag for kruise-rollout image                                      | `v0.6.2`                            |
+| `image.tag`                      | Tag for kruise-rollout image                                      | `v0.6.1`                            |
 | `image.pullPolicy`               | ImagePullPolicy for kruise-rollout container                      | `Always`                            |
 | `imagePullSecrets`               | The list of image pull secrets for kruise-rollout image           | ` `                                 |
 | `resources.limits.cpu`           | CPU resource limit of kruise-rollout container                    | `500m`                              |

--- a/versions/kruise-rollout/0.6.2/README.md
+++ b/versions/kruise-rollout/0.6.2/README.md
@@ -1,4 +1,4 @@
-# Kruise Rollout v0.6.1
+# Kruise Rollout v0.6.2
 
 ## Configuration
 
@@ -16,7 +16,7 @@ The following table lists the configurable parameters of the kruise chart and th
 | `rollout.webhook.port`           | Port of webhook served by kruise-rollout container                | `9876`                              |
 | `rollout.webhook.objectSelector` | ObjectSelector for workloads in MutatingWebhookConfigurations     | ` `                                 |
 | `image.repository`               | Repository for kruise-rollout image                               | `openkruise/kruise-rollout`         |
-| `image.tag`                      | Tag for kruise-rollout image                                      | `v0.6.1`                            |
+| `image.tag`                      | Tag for kruise-rollout image                                      | `v0.6.2`                            |
 | `image.pullPolicy`               | ImagePullPolicy for kruise-rollout container                      | `Always`                            |
 | `imagePullSecrets`               | The list of image pull secrets for kruise-rollout image           | ` `                                 |
 | `resources.limits.cpu`           | CPU resource limit of kruise-rollout container                    | `500m`                              |

--- a/versions/kruise-rollout/0.6.2/templates/_helpers.tpl
+++ b/versions/kruise-rollout/0.6.2/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rollout.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rollout.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rollout.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rollout.labels" -}}
+helm.sh/chart: {{ include "rollout.chart" . }}
+{{ include "rollout.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rollout.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rollout.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rollout.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rollout.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/versions/kruise-rollout/0.6.2/templates/manager.yaml
+++ b/versions/kruise-rollout/0.6.2/templates/manager.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.installation.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: {{ .Values.rollout.fullname }}
+  name: {{ .Values.installation.namespace }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kruise-rollout-webhook-service
+  namespace: {{ .Values.installation.namespace }}
+spec:
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.rollout.webhook.port }}
+  selector:
+    control-plane: {{ .Values.rollout.fullname }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.rollout.fullname }}
+  namespace: {{ .Values.installation.namespace }}
+  labels:
+    control-plane: {{ .Values.rollout.fullname }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      control-plane: {{ .Values.rollout.fullname }}
+  minReadySeconds: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      labels:
+        control-plane: {{ .Values.rollout.fullname }}
+    spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+      serviceAccountName: {{ .Values.rollout.fullname }}
+      containers:
+        - name: {{ .Chart.Name }}
+          args:
+            - --leader-elect
+            - --health-probe-bind-address=:{{ .Values.rollout.healthBindPort }}
+            - --metrics-bind-address={{ .Values.rollout.metricsBindAddr }}
+            - --v={{ .Values.rollout.log.level }}
+            {{- if .Values.rollout.featureGates }}
+            - --feature-gates={{ .Values.rollout.featureGates }}
+            {{- end }}
+          command:
+            - /manager
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: {{ .Values.rollout.webhook.port }}
+              name: webhook-server
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.rollout.healthBindPort }}
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: {{ .Values.rollout.healthBindPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: control-plane
+                      operator: In
+                      values:
+                        - {{ .Values.rollout.fullname }}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            control-plane: {{ .Values.rollout.fullname }}
+{{- if and ( eq (int .Capabilities.KubeVersion.Major) 1) ( gt (int .Capabilities.KubeVersion.Minor) 26 ) }}
+        matchLabelKeys:
+        - pod-template-hash
+{{- end }}
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable:  ScheduleAnyway
+      {{- with .Values.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/versions/kruise-rollout/0.6.2/templates/rbac_role.yaml
+++ b/versions/kruise-rollout/0.6.2/templates/rbac_role.yaml
@@ -1,0 +1,478 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "rollout.name" . }}-controller-manager
+  namespace: {{ .Values.installation.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kruise-rollout-manager-role
+  namespace: {{ .Values.installation.namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "rollout.name" . }}-leader-election-role
+  namespace: {{ .Values.installation.namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kruise-rollout-manager-role
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - clonesets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - clonesets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - daemonsets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - statefulsets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - destinationrules
+      - virtualservices
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - batchreleases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - batchreleases/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - rollouthistories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - rollouthistories/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - rollouthistories/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - rollouts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - rollouts/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - rollouts/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - trafficroutings
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - trafficroutings/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - rollouts.kruise.io
+    resources:
+      - trafficroutings/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kruise-rollout-manager-rolebinding
+  namespace: {{ .Values.installation.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kruise-rollout-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: kruise-rollout-controller-manager
+    namespace: {{ .Values.installation.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "rollout.name" . }}-leader-election-rolebinding
+  namespace: {{ .Values.installation.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "rollout.name" . }}-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "rollout.name" . }}-controller-manager
+    namespace: {{ .Values.installation.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "rollout.name" . }}-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "rollout.name" . }}-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "rollout.name" . }}-controller-manager
+    namespace: {{ .Values.installation.namespace }}

--- a/versions/kruise-rollout/0.6.2/templates/rollouts.kruise.io_batchreleases.yaml
+++ b/versions/kruise-rollout/0.6.2/templates/rollouts.kruise.io_batchreleases.yaml
@@ -1,0 +1,569 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.0
+  name: batchreleases.rollouts.kruise.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: kruise-rollout-webhook-service
+          namespace: {{ .Values.installation.namespace }}
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+  group: rollouts.kruise.io
+  names:
+    kind: BatchRelease
+    listKind: BatchReleaseList
+    plural: batchreleases
+    singular: batchrelease
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.targetReference.workloadRef.kind
+      name: KIND
+      type: string
+    - jsonPath: .status.phase
+      name: PHASE
+      type: string
+    - jsonPath: .status.canaryStatus.currentBatch
+      name: BATCH
+      type: integer
+    - jsonPath: .status.canaryStatus.batchState
+      name: BATCH-STATE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BatchReleaseSpec defines how to describe an update between
+              different compRevision
+            properties:
+              releasePlan:
+                description: ReleasePlan is the details on how to rollout the resources
+                properties:
+                  batchPartition:
+                    description: All pods in the batches up to the batchPartition
+                      (included) will have the target resource specification while
+                      the rest still is the stable revision. This is designed for
+                      the operators to manually rollout. Default is nil, which means
+                      no partition and will release all batches. BatchPartition start
+                      from 0.
+                    format: int32
+                    type: integer
+                  batches:
+                    description: 'Batches is the details on each batch of the ReleasePlan.
+                      Users can specify their batch plan in this field, such as: batches:
+                      - canaryReplicas: 1  # batches 0 - canaryReplicas: 2  # batches
+                      1 - canaryReplicas: 5  # batches 2 Not that these canaryReplicas
+                      should be a non-decreasing sequence.'
+                    items:
+                      description: ReleaseBatch is used to describe how each batch
+                        release should be
+                      properties:
+                        canaryReplicas:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'CanaryReplicas is the number of upgraded pods
+                            that should have in this batch. it can be an absolute
+                            number (ex: 5) or a percentage of workload replicas. batches[i].canaryReplicas
+                            should less than or equal to batches[j].canaryReplicas
+                            if i < j.'
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - canaryReplicas
+                      type: object
+                    type: array
+                  enableExtraWorkloadForCanary:
+                    description: EnableExtraWorkloadForCanary indicates whether to
+                      create extra workload for canary True corresponds to RollingStyle
+                      "Canary". False corresponds to RollingStyle "Partiton". Ignored
+                      in BlueGreen-style. This field is about to deprecate, use RollingStyle
+                      instead. If both of them are set, controller will only consider
+                      this filed when RollingStyle is empty
+                    type: boolean
+                  failureThreshold:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: FailureThreshold indicates how many failed pods can
+                      be tolerated in all upgraded pods. Only when FailureThreshold
+                      are satisfied, Rollout can enter ready state. If FailureThreshold
+                      is nil, Rollout will use the MaxUnavailable of workload as its
+                      FailureThreshold. Defaults to nil.
+                    x-kubernetes-int-or-string: true
+                  finalizingPolicy:
+                    description: FinalizingPolicy define the behavior of controller
+                      when phase enter Finalizing Defaults to "Immediate"
+                    type: string
+                  patchPodTemplateMetadata:
+                    description: PatchPodTemplateMetadata indicates patch configuration(e.g.
+                      labels, annotations) to the canary deployment podTemplateSpec.metadata
+                      only support for canary deployment
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: labels
+                        type: object
+                    type: object
+                  rollingStyle:
+                    description: RollingStyle can be "Canary", "Partiton" or "BlueGreen"
+                    type: string
+                  rolloutID:
+                    description: RolloutID indicates an id for each rollout progress
+                    type: string
+                required:
+                - enableExtraWorkloadForCanary
+                type: object
+              targetReference:
+                description: TargetRef contains the GVK and name of the workload that
+                  we need to upgrade to.
+                properties:
+                  workloadRef:
+                    description: WorkloadRef contains enough information to let you
+                      identify a workload for Rollout Batch release of the bypass
+                    properties:
+                      apiVersion:
+                        description: API Version of the referent
+                        type: string
+                      kind:
+                        description: Kind of the referent
+                        type: string
+                      name:
+                        description: Name of the referent
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    type: object
+                type: object
+            required:
+            - releasePlan
+            - targetReference
+            type: object
+          status:
+            description: BatchReleaseStatus defines the observed state of a release
+              plan
+            properties:
+              canaryStatus:
+                description: CanaryStatus describes the state of the canary rollout.
+                properties:
+                  batchReadyTime:
+                    description: BatchReadyTime is the ready timestamp of the current
+                      batch or the last batch. This field is updated once a batch
+                      ready, and the batches[x].pausedSeconds relies on this field
+                      to calculate the real-time duration.
+                    format: date-time
+                    type: string
+                  batchState:
+                    description: CurrentBatchState indicates the release state of
+                      the current batch.
+                    type: string
+                  currentBatch:
+                    description: The current batch the rollout is working on/blocked,
+                      it starts from 0
+                    format: int32
+                    type: integer
+                  noNeedUpdateReplicas:
+                    description: the number of pods that no need to rollback in rollback
+                      scene.
+                    format: int32
+                    type: integer
+                  updatedReadyReplicas:
+                    description: UpdatedReadyReplicas is the number upgraded Pods
+                      that have a Ready Condition.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: UpdatedReplicas is the number of upgraded Pods.
+                    format: int32
+                    type: integer
+                required:
+                - currentBatch
+                type: object
+              collisionCount:
+                description: Count of hash collisions for creating canary Deployment.
+                  The controller uses this field as a collision avoidance mechanism
+                  when it needs to create the name for the newest canary Deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions represents the observed process state of each
+                  phase during executing the release plan.
+                items:
+                  description: RolloutCondition describes the state of a rollout at
+                    a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Phase of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of rollout condition.
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this BatchRelease. It corresponds to this BatchRelease's generation,
+                  which is updated on mutation by the API Server, and only if BatchRelease
+                  Spec was changed, its generation will increase 1.
+                format: int64
+                type: integer
+              observedReleasePlanHash:
+                description: ObservedReleasePlanHash is a hash code of observed itself
+                  spec.releasePlan.
+                type: string
+              observedRolloutID:
+                description: ObservedRolloutID is the most recent rollout-id observed
+                  for this BatchRelease. If RolloutID was changed, we will restart
+                  to roll out from batch 0, to ensure the batch-id and rollout-id
+                  labels of Pods are correct.
+                type: string
+              observedWorkloadReplicas:
+                description: ObservedWorkloadReplicas is observed replicas of target
+                  referenced workload. This field is designed to deal with scaling
+                  event during rollout, if this field changed, it means that the workload
+                  is scaling during rollout.
+                format: int32
+                type: integer
+              phase:
+                description: Phase is the release plan phase, which indicates the
+                  current state of release plan state machine in BatchRelease controller.
+                type: string
+              stableRevision:
+                description: StableRevision is the pod-template-hash of stable revision
+                  pod template.
+                type: string
+              updateRevision:
+                description: UpdateRevision is the pod-template-hash of update revision
+                  pod template.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.targetReference.workloadRef.kind
+      name: KIND
+      type: string
+    - jsonPath: .status.phase
+      name: PHASE
+      type: string
+    - jsonPath: .status.canaryStatus.currentBatch
+      name: BATCH
+      type: integer
+    - jsonPath: .status.canaryStatus.batchState
+      name: BATCH-STATE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BatchReleaseSpec defines how to describe an update between
+              different compRevision
+            properties:
+              releasePlan:
+                description: ReleasePlan is the details on how to rollout the resources
+                properties:
+                  batchPartition:
+                    description: All pods in the batches up to the batchPartition
+                      (included) will have the target resource specification while
+                      the rest still is the stable revision. This is designed for
+                      the operators to manually rollout. Default is nil, which means
+                      no partition and will release all batches. BatchPartition start
+                      from 0.
+                    format: int32
+                    type: integer
+                  batches:
+                    description: 'Batches is the details on each batch of the ReleasePlan.
+                      Users can specify their batch plan in this field, such as: batches:
+                      - canaryReplicas: 1  # batches 0 - canaryReplicas: 2  # batches
+                      1 - canaryReplicas: 5  # batches 2 Not that these canaryReplicas
+                      should be a non-decreasing sequence.'
+                    items:
+                      description: ReleaseBatch is used to describe how each batch
+                        release should be
+                      properties:
+                        canaryReplicas:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'CanaryReplicas is the number of upgraded pods
+                            that should have in this batch. it can be an absolute
+                            number (ex: 5) or a percentage of workload replicas. batches[i].canaryReplicas
+                            should less than or equal to batches[j].canaryReplicas
+                            if i < j.'
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - canaryReplicas
+                      type: object
+                    type: array
+                  enableExtraWorkloadForCanary:
+                    description: EnableExtraWorkloadForCanary indicates whether to
+                      create extra workload for canary True corresponds to RollingStyle
+                      "Canary". False corresponds to RollingStyle "Partiton". Ignored
+                      in BlueGreen-style. This field is about to deprecate, use RollingStyle
+                      instead. If both of them are set, controller will only consider
+                      this filed when RollingStyle is empty
+                    type: boolean
+                  failureThreshold:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: FailureThreshold indicates how many failed pods can
+                      be tolerated in all upgraded pods. Only when FailureThreshold
+                      are satisfied, Rollout can enter ready state. If FailureThreshold
+                      is nil, Rollout will use the MaxUnavailable of workload as its
+                      FailureThreshold. Defaults to nil.
+                    x-kubernetes-int-or-string: true
+                  finalizingPolicy:
+                    description: FinalizingPolicy define the behavior of controller
+                      when phase enter Finalizing Defaults to "Immediate"
+                    type: string
+                  patchPodTemplateMetadata:
+                    description: PatchPodTemplateMetadata indicates patch configuration(e.g.
+                      labels, annotations) to the canary deployment podTemplateSpec.metadata
+                      only support for canary deployment
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: labels
+                        type: object
+                    type: object
+                  rollingStyle:
+                    description: RollingStyle can be "Canary", "Partiton" or "BlueGreen"
+                    type: string
+                  rolloutID:
+                    description: RolloutID indicates an id for each rollout progress
+                    type: string
+                required:
+                - enableExtraWorkloadForCanary
+                type: object
+              workloadRef:
+                description: WorkloadRef contains enough information to let you identify
+                  a workload for Rollout Batch release of the bypass
+                properties:
+                  apiVersion:
+                    description: API Version of the referent
+                    type: string
+                  kind:
+                    description: Kind of the referent
+                    type: string
+                  name:
+                    description: Name of the referent
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            required:
+            - releasePlan
+            type: object
+          status:
+            description: BatchReleaseStatus defines the observed state of a release
+              plan
+            properties:
+              canaryStatus:
+                description: CanaryStatus describes the state of the canary rollout.
+                properties:
+                  batchReadyTime:
+                    description: BatchReadyTime is the ready timestamp of the current
+                      batch or the last batch. This field is updated once a batch
+                      ready, and the batches[x].pausedSeconds relies on this field
+                      to calculate the real-time duration.
+                    format: date-time
+                    type: string
+                  batchState:
+                    description: CurrentBatchState indicates the release state of
+                      the current batch.
+                    type: string
+                  currentBatch:
+                    description: The current batch the rollout is working on/blocked,
+                      it starts from 0
+                    format: int32
+                    type: integer
+                  noNeedUpdateReplicas:
+                    description: the number of pods that no need to rollback in rollback
+                      scene.
+                    format: int32
+                    type: integer
+                  updatedReadyReplicas:
+                    description: UpdatedReadyReplicas is the number upgraded Pods
+                      that have a Ready Condition.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: UpdatedReplicas is the number of upgraded Pods.
+                    format: int32
+                    type: integer
+                required:
+                - currentBatch
+                type: object
+              collisionCount:
+                description: Count of hash collisions for creating canary Deployment.
+                  The controller uses this field as a collision avoidance mechanism
+                  when it needs to create the name for the newest canary Deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions represents the observed process state of each
+                  phase during executing the release plan.
+                items:
+                  description: RolloutCondition describes the state of a rollout at
+                    a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Phase of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of rollout condition.
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                description: Message provides details on why the rollout is in its
+                  current phase
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this BatchRelease. It corresponds to this BatchRelease's generation,
+                  which is updated on mutation by the API Server, and only if BatchRelease
+                  Spec was changed, its generation will increase 1.
+                format: int64
+                type: integer
+              observedReleasePlanHash:
+                description: ObservedReleasePlanHash is a hash code of observed itself
+                  spec.releasePlan.
+                type: string
+              observedRolloutID:
+                description: ObservedRolloutID is the most recent rollout-id observed
+                  for this BatchRelease. If RolloutID was changed, we will restart
+                  to roll out from batch 0, to ensure the batch-id and rollout-id
+                  labels of Pods are correct.
+                type: string
+              observedWorkloadReplicas:
+                description: ObservedWorkloadReplicas is observed replicas of target
+                  referenced workload. This field is designed to deal with scaling
+                  event during rollout, if this field changed, it means that the workload
+                  is scaling during rollout.
+                format: int32
+                type: integer
+              phase:
+                description: Phase is the release plan phase, which indicates the
+                  current state of release plan state machine in BatchRelease controller.
+                type: string
+              stableRevision:
+                description: StableRevision is the pod-template-hash of stable revision
+                  pod template.
+                type: string
+              updateRevision:
+                description: UpdateRevision is the pod-template-hash of update revision
+                  pod template.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/versions/kruise-rollout/0.6.2/templates/rollouts.kruise.io_rollouthistories.yaml
+++ b/versions/kruise-rollout/0.6.2/templates/rollouts.kruise.io_rollouthistories.yaml
@@ -1,0 +1,174 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.0
+  creationTimestamp: null
+  name: rollouthistories.rollouts.kruise.io
+spec:
+  group: rollouts.kruise.io
+  names:
+    kind: RolloutHistory
+    listKind: RolloutHistoryList
+    plural: rollouthistories
+    singular: rollouthistory
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RolloutHistory is the Schema for the rollouthistories API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RolloutHistorySpec defines the desired state of RolloutHistory
+            properties:
+              rollout:
+                description: Rollout indicates information of the rollout related
+                  with rollouthistory
+                properties:
+                  data:
+                    description: Data indecates the spec of object ref
+                    x-kubernetes-preserve-unknown-fields: true
+                  name:
+                    description: Name indicates the name of object ref, such as rollout
+                      name, workload name, ingress name, etc.
+                    type: string
+                  rolloutID:
+                    description: RolloutID indicates the new rollout if there is no
+                      new RolloutID this time, ignore it and not execute RolloutHistory
+                    type: string
+                required:
+                - name
+                - rolloutID
+                type: object
+              service:
+                description: Service indicates information of the service related
+                  with workload
+                properties:
+                  data:
+                    description: Data indecates the spec of object ref
+                    x-kubernetes-preserve-unknown-fields: true
+                  name:
+                    description: Name indicates the name of object ref, such as rollout
+                      name, workload name, ingress name, etc.
+                    type: string
+                required:
+                - name
+                type: object
+              trafficRouting:
+                description: TrafficRouting indicates information of traffic route
+                  related with workload
+                properties:
+                  httpRoute:
+                    description: HTTPRouteRef indacates information of Gateway API
+                    properties:
+                      data:
+                        description: Data indecates the spec of object ref
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        description: Name indicates the name of object ref, such as
+                          rollout name, workload name, ingress name, etc.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  ingress:
+                    description: IngressRef indicates information of ingress
+                    properties:
+                      data:
+                        description: Data indecates the spec of object ref
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        description: Name indicates the name of object ref, such as
+                          rollout name, workload name, ingress name, etc.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              workload:
+                description: Workload indicates information of the workload, such
+                  as cloneset, deployment, advanced statefulset
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  data:
+                    description: Data indecates the spec of object ref
+                    x-kubernetes-preserve-unknown-fields: true
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: Name indicates the name of object ref, such as rollout
+                      name, workload name, ingress name, etc.
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: RolloutHistoryStatus defines the observed state of RolloutHistory
+            properties:
+              canarySteps:
+                description: CanarySteps indicates the pods released each step
+                items:
+                  description: CanaryStepInfo indicates the pods for a revision
+                  properties:
+                    canaryStepIndex:
+                      description: CanaryStepIndex indicates step this revision
+                      format: int32
+                      type: integer
+                    pods:
+                      description: Pods indicates the pods information
+                      items:
+                        description: Pod indicates the information of a pod, including
+                          name, ip, node_name.
+                        properties:
+                          ip:
+                            description: IP indicates the pod ip
+                            type: string
+                          name:
+                            description: Name indicates the node name
+                            type: string
+                          nodeName:
+                            description: NodeName indicates the node which pod is
+                              located at
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              phase:
+                description: Phase indicates phase of RolloutHistory, just "" or "completed"
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/versions/kruise-rollout/0.6.2/templates/rollouts.kruise.io_rollouts.yaml
+++ b/versions/kruise-rollout/0.6.2/templates/rollouts.kruise.io_rollouts.yaml
@@ -1,0 +1,1670 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.0
+  name: rollouts.rollouts.kruise.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: kruise-rollout-webhook-service
+          namespace: {{ .Values.installation.namespace }}
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+  group: rollouts.kruise.io
+  names:
+    kind: Rollout
+    listKind: RolloutList
+    plural: rollouts
+    singular: rollout
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The rollout status phase
+      jsonPath: .status.phase
+      name: STATUS
+      type: string
+    - description: The rollout canary status step
+      jsonPath: .status.canaryStatus.currentStepIndex
+      name: CANARY_STEP
+      type: integer
+    - description: The rollout canary status step state
+      jsonPath: .status.canaryStatus.currentStepState
+      name: CANARY_STATE
+      type: string
+    - description: The rollout canary status message
+      jsonPath: .status.message
+      name: MESSAGE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Rollout is the Schema for the rollouts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RolloutSpec defines the desired state of Rollout
+            properties:
+              disabled:
+                default: false
+                description: if a rollout disabled, then the rollout would not watch
+                  changes of workload
+                type: boolean
+              objectRef:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
+                  ObjectRef indicates workload'
+                properties:
+                  workloadRef:
+                    description: WorkloadRef contains enough information to let you
+                      identify a workload for Rollout Batch release of the bypass
+                    properties:
+                      apiVersion:
+                        description: API Version of the referent
+                        type: string
+                      kind:
+                        description: Kind of the referent
+                        type: string
+                      name:
+                        description: Name of the referent
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    type: object
+                type: object
+              rolloutID:
+                description: DeprecatedRolloutID is the deprecated field. It is recommended
+                  that configure RolloutId in workload.annotations[rollouts.kruise.io/rollout-id].
+                  RolloutID should be changed before each workload revision publication.
+                  It is to distinguish consecutive multiple workload publications
+                  and rollout progress.
+                type: string
+              strategy:
+                description: rollout strategy
+                properties:
+                  canary:
+                    description: CanaryStrategy defines parameters for a Replica Based
+                      Canary
+                    properties:
+                      disableGenerateCanaryService:
+                        description: canary service will not be generated if DisableGenerateCanaryService
+                          is true
+                        type: boolean
+                      failureThreshold:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: FailureThreshold indicates how many failed pods
+                          can be tolerated in all upgraded pods. Only when FailureThreshold
+                          are satisfied, Rollout can enter ready state. If FailureThreshold
+                          is nil, Rollout will use the MaxUnavailable of workload
+                          as its FailureThreshold. Defaults to nil.
+                        x-kubernetes-int-or-string: true
+                      patchPodTemplateMetadata:
+                        description: PatchPodTemplateMetadata indicates patch configuration(e.g.
+                          labels, annotations) to the canary deployment podTemplateSpec.metadata
+                          only support for canary deployment
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: labels
+                            type: object
+                        type: object
+                      steps:
+                        description: Steps define the order of phases to execute release
+                          in batches(20%, 40%, 60%, 80%, 100%)
+                        items:
+                          description: CanaryStep defines a step of a canary workload.
+                          properties:
+                            matches:
+                              description: Matches define conditions used for matching
+                                the incoming HTTP requests to canary service. Each
+                                match is independent, i.e. this rule will be matched
+                                if **any** one of the matches is satisfied. If Gateway
+                                API, current only support one match. And cannot support
+                                both weight and matches, if both are configured, then
+                                matches takes precedence.
+                              items:
+                                properties:
+                                  headers:
+                                    description: Headers specifies HTTP request header
+                                      matchers. Multiple match values are ANDed together,
+                                      meaning, a request must match all the specified
+                                      headers to select the route.
+                                    items:
+                                      description: HTTPHeaderMatch describes how to
+                                        select a HTTP route by matching HTTP request
+                                        headers.
+                                      properties:
+                                        name:
+                                          description: "Name is the name of the HTTP
+                                            Header to be matched. Name matching MUST
+                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                            \n If multiple entries specify equivalent
+                                            header names, only the first entry with
+                                            an equivalent name MUST be considered
+                                            for a match. Subsequent entries with an
+                                            equivalent header name MUST be ignored.
+                                            Due to the case-insensitivity of header
+                                            names, \"foo\" and \"Foo\" are considered
+                                            equivalent. \n When a header is repeated
+                                            in an HTTP request, it is implementation-specific
+                                            behavior as to how this is represented.
+                                            Generally, proxies should follow the guidance
+                                            from the RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                            regarding processing a repeated header,
+                                            with special handling for \"Set-Cookie\"."
+                                          maxLength: 256
+                                          minLength: 1
+                                          pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          type: string
+                                        type:
+                                          default: Exact
+                                          description: "Type specifies how to match
+                                            against the value of the header. \n Support:
+                                            Core (Exact) \n Support: Implementation-specific
+                                            (RegularExpression) \n Since RegularExpression
+                                            HeaderMatchType has implementation-specific
+                                            conformance, implementations can support
+                                            POSIX, PCRE or any other dialects of regular
+                                            expressions. Please read the implementation's
+                                            documentation to determine the supported
+                                            dialect."
+                                          enum:
+                                          - Exact
+                                          - RegularExpression
+                                          type: string
+                                        value:
+                                          description: Value is the value of HTTP
+                                            Header to be matched.
+                                          maxLength: 4096
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    maxItems: 16
+                                    type: array
+                                type: object
+                              type: array
+                            pause:
+                              description: Pause defines a pause stage for a rollout,
+                                manual or auto
+                              properties:
+                                duration:
+                                  description: Duration the amount of time to wait
+                                    before moving to the next step.
+                                  format: int32
+                                  type: integer
+                              type: object
+                            replicas:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Replicas is the number of expected canary
+                                pods in this batch it can be an absolute number (ex:
+                                5) or a percentage of total pods.'
+                              x-kubernetes-int-or-string: true
+                            requestHeaderModifier:
+                              description: "Set overwrites the request with the given
+                                header (name, value) before the action. \n Input:
+                                GET /foo HTTP/1.1 my-header: foo \n requestHeaderModifier:
+                                set: - name: \"my-header\" value: \"bar\" \n Output:
+                                GET /foo HTTP/1.1 my-header: bar"
+                              properties:
+                                add:
+                                  description: "Add adds the given header(s) (name,
+                                    value) to the request before the action. It appends
+                                    to any existing values associated with the header
+                                    name. \n Input: GET /foo HTTP/1.1 my-header: foo
+                                    \n Config: add: - name: \"my-header\" value: \"bar,baz\"
+                                    \n Output: GET /foo HTTP/1.1 my-header: foo,bar,baz"
+                                  items:
+                                    description: HTTPHeader represents an HTTP Header
+                                      name and value as defined by RFC 7230.
+                                    properties:
+                                      name:
+                                        description: "Name is the name of the HTTP
+                                          Header to be matched. Name matching MUST
+                                          be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                          \n If multiple entries specify equivalent
+                                          header names, the first entry with an equivalent
+                                          name MUST be considered for a match. Subsequent
+                                          entries with an equivalent header name MUST
+                                          be ignored. Due to the case-insensitivity
+                                          of header names, \"foo\" and \"Foo\" are
+                                          considered equivalent."
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      value:
+                                        description: Value is the value of HTTP Header
+                                          to be matched.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 16
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                remove:
+                                  description: "Remove the given header(s) from the
+                                    HTTP request before the action. The value of Remove
+                                    is a list of HTTP header names. Note that the
+                                    header names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                    \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
+                                    bar my-header3: baz \n Config: remove: [\"my-header1\",
+                                    \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
+                                    bar"
+                                  items:
+                                    type: string
+                                  maxItems: 16
+                                  type: array
+                                set:
+                                  description: "Set overwrites the request with the
+                                    given header (name, value) before the action.
+                                    \n Input: GET /foo HTTP/1.1 my-header: foo \n
+                                    Config: set: - name: \"my-header\" value: \"bar\"
+                                    \n Output: GET /foo HTTP/1.1 my-header: bar"
+                                  items:
+                                    description: HTTPHeader represents an HTTP Header
+                                      name and value as defined by RFC 7230.
+                                    properties:
+                                      name:
+                                        description: "Name is the name of the HTTP
+                                          Header to be matched. Name matching MUST
+                                          be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                          \n If multiple entries specify equivalent
+                                          header names, the first entry with an equivalent
+                                          name MUST be considered for a match. Subsequent
+                                          entries with an equivalent header name MUST
+                                          be ignored. Due to the case-insensitivity
+                                          of header names, \"foo\" and \"Foo\" are
+                                          considered equivalent."
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      value:
+                                        description: Value is the value of HTTP Header
+                                          to be matched.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 16
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                            weight:
+                              description: Weight indicate how many percentage of
+                                traffic the canary pods should receive
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                      trafficRoutings:
+                        description: TrafficRoutings hosts all the supported service
+                          meshes supported to enable more fine-grained traffic routing
+                          and current only support one TrafficRouting
+                        items:
+                          description: TrafficRoutingRef hosts all the different configuration
+                            for supported service meshes to enable more fine-grained
+                            traffic routing
+                          properties:
+                            customNetworkRefs:
+                              description: CustomNetworkRefs hold a list of custom
+                                providers to route traffic
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - apiVersion
+                                - kind
+                                - name
+                                type: object
+                              type: array
+                            gateway:
+                              description: Gateway holds Gateway specific configuration
+                                to route traffic Gateway configuration only supports
+                                >= v0.4.0 (v1alpha2).
+                              properties:
+                                httpRouteName:
+                                  description: HTTPRouteName refers to the name of
+                                    an `HTTPRoute` resource in the same namespace
+                                    as the `Rollout`
+                                  type: string
+                              type: object
+                            gracePeriodSeconds:
+                              default: 3
+                              description: Optional duration in seconds the traffic
+                                provider(e.g. nginx ingress controller) consumes the
+                                service, ingress configuration changes gracefully.
+                              format: int32
+                              type: integer
+                            ingress:
+                              description: Ingress holds Ingress specific configuration
+                                to route traffic, e.g. Nginx, Alb.
+                              properties:
+                                classType:
+                                  description: ClassType refers to the type of `Ingress`.
+                                    current support nginx, aliyun-alb. default is
+                                    nginx.
+                                  type: string
+                                name:
+                                  description: Name refers to the name of an `Ingress`
+                                    resource in the same namespace as the `Rollout`
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            service:
+                              description: Service holds the name of a service which
+                                selects pods with stable version and don't select
+                                any pods with canary version.
+                              type: string
+                          required:
+                          - service
+                          type: object
+                        type: array
+                    type: object
+                  paused:
+                    description: Paused indicates that the Rollout is paused. Default
+                      value is false
+                    type: boolean
+                type: object
+            required:
+            - objectRef
+            - strategy
+            type: object
+          status:
+            description: RolloutStatus defines the observed state of Rollout
+            properties:
+              canaryStatus:
+                description: Canary describes the state of the canary rollout
+                properties:
+                  canaryReadyReplicas:
+                    description: CanaryReadyReplicas the numbers of ready canary revision
+                      pods
+                    format: int32
+                    type: integer
+                  canaryReplicas:
+                    description: CanaryReplicas the numbers of canary revision pods
+                    format: int32
+                    type: integer
+                  canaryRevision:
+                    description: CanaryRevision is calculated by rollout based on
+                      podTemplateHash, and the internal logic flow uses It may be
+                      different from rs podTemplateHash in different k8s versions,
+                      so it cannot be used as service selector label
+                    type: string
+                  currentStepIndex:
+                    format: int32
+                    type: integer
+                  currentStepState:
+                    type: string
+                  finalisingStep:
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  nextStepIndex:
+                    description: NextStepIndex defines the next step of the rollout
+                      is on. In normal case, NextStepIndex is equal to CurrentStepIndex
+                      + 1 If the current step is the last step, NextStepIndex is equal
+                      to -1 Before the release, NextStepIndex is also equal to -1
+                      0 is not used and won't appear in any case It is allowed to
+                      patch NextStepIndex by design, e.g. if CurrentStepIndex is 2,
+                      user can patch NextStepIndex to 3 (if exists) to achieve batch
+                      jump, or patch NextStepIndex to 1 to implement a re-execution
+                      of step 1 Patching it with a non-positive value is meaningless,
+                      which will be corrected in the next reconciliation achieve batch
+                      jump, or patch NextStepIndex to 1 to implement a re-execution
+                      of step 1
+                    format: int32
+                    type: integer
+                  observedRolloutID:
+                    description: ObservedRolloutID will record the newest spec.RolloutID
+                      if status.canaryRevision equals to workload.updateRevision
+                    type: string
+                  observedWorkloadGeneration:
+                    description: observedWorkloadGeneration is the most recent generation
+                      observed for this Rollout ref workload generation.
+                    format: int64
+                    type: integer
+                  podTemplateHash:
+                    description: pod template hash is used as service selector label
+                    type: string
+                  rolloutHash:
+                    description: RolloutHash from rollout.spec object
+                    type: string
+                  stableRevision:
+                    description: StableRevision indicates the revision of stable pods
+                    type: string
+                required:
+                - canaryReadyReplicas
+                - canaryReplicas
+                - canaryRevision
+                - currentStepState
+                - finalisingStep
+                - nextStepIndex
+                - podTemplateHash
+                type: object
+              conditions:
+                description: Conditions a list of conditions a rollout can have.
+                items:
+                  description: RolloutCondition describes the state of a rollout at
+                    a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Phase of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of rollout condition.
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                description: Message provides details on why the rollout is in its
+                  current phase
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this Rollout.
+                format: int64
+                type: integer
+              phase:
+                description: Phase is the rollout phase.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The rollout status phase
+      jsonPath: .status.phase
+      name: STATUS
+      type: string
+    - description: The rollout canary status step
+      jsonPath: .status.currentStepIndex
+      name: CANARY_STEP
+      type: integer
+    - description: The rollout canary status step state
+      jsonPath: .status.currentStepState
+      name: CANARY_STATE
+      type: string
+    - description: The rollout canary status message
+      jsonPath: .status.message
+      name: MESSAGE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Rollout is the Schema for the rollouts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RolloutSpec defines the desired state of Rollout
+            properties:
+              disabled:
+                default: false
+                description: if a rollout disabled, then the rollout would not watch
+                  changes of workload
+                type: boolean
+              strategy:
+                description: rollout strategy
+                properties:
+                  blueGreen:
+                    description: BlueGreenStrategy defines parameters for Blue Green
+                      Release
+                    properties:
+                      disableGenerateCanaryService:
+                        description: canary service will not be generated if DisableGenerateCanaryService
+                          is true
+                        type: boolean
+                      failureThreshold:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: FailureThreshold indicates how many failed pods
+                          can be tolerated in all upgraded pods. Only when FailureThreshold
+                          are satisfied, Rollout can enter ready state. If FailureThreshold
+                          is nil, Rollout will use the MaxUnavailable of workload
+                          as its FailureThreshold. Defaults to nil.
+                        x-kubernetes-int-or-string: true
+                      steps:
+                        description: Steps define the order of phases to execute release
+                          in batches(20%, 40%, 60%, 80%, 100%)
+                        items:
+                          description: CanaryStep defines a step of a canary workload.
+                          properties:
+                            matches:
+                              description: "Matches define conditions used for matching
+                                incoming HTTP requests to the canary service. Each
+                                match is independent, i.e. this rule will be matched
+                                as long as **any** one of the matches is satisfied.
+                                \n It cannot support Traffic (weight-based routing)
+                                and Matches simultaneously, if both are configured.
+                                In such cases, Matches takes precedence."
+                              items:
+                                properties:
+                                  headers:
+                                    description: Headers specifies HTTP request header
+                                      matchers. Multiple match values are ANDed together,
+                                      meaning, a request must match all the specified
+                                      headers to select the route.
+                                    items:
+                                      description: HTTPHeaderMatch describes how to
+                                        select a HTTP route by matching HTTP request
+                                        headers.
+                                      properties:
+                                        name:
+                                          description: "Name is the name of the HTTP
+                                            Header to be matched. Name matching MUST
+                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                            \n If multiple entries specify equivalent
+                                            header names, only the first entry with
+                                            an equivalent name MUST be considered
+                                            for a match. Subsequent entries with an
+                                            equivalent header name MUST be ignored.
+                                            Due to the case-insensitivity of header
+                                            names, \"foo\" and \"Foo\" are considered
+                                            equivalent. \n When a header is repeated
+                                            in an HTTP request, it is implementation-specific
+                                            behavior as to how this is represented.
+                                            Generally, proxies should follow the guidance
+                                            from the RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                            regarding processing a repeated header,
+                                            with special handling for \"Set-Cookie\"."
+                                          maxLength: 256
+                                          minLength: 1
+                                          pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          type: string
+                                        type:
+                                          default: Exact
+                                          description: "Type specifies how to match
+                                            against the value of the header. \n Support:
+                                            Core (Exact) \n Support: Implementation-specific
+                                            (RegularExpression) \n Since RegularExpression
+                                            HeaderMatchType has implementation-specific
+                                            conformance, implementations can support
+                                            POSIX, PCRE or any other dialects of regular
+                                            expressions. Please read the implementation's
+                                            documentation to determine the supported
+                                            dialect."
+                                          enum:
+                                          - Exact
+                                          - RegularExpression
+                                          type: string
+                                        value:
+                                          description: Value is the value of HTTP
+                                            Header to be matched.
+                                          maxLength: 4096
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    maxItems: 16
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  path:
+                                    description: 'Path specifies a HTTP request path
+                                      matcher. Supported list: - Istio: https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest
+                                      - GatewayAPI: If path is defined, the whole
+                                      HttpRouteMatch will be used as a standalone
+                                      matcher'
+                                    properties:
+                                      type:
+                                        default: PathPrefix
+                                        description: "Type specifies how to match
+                                          against the path Value. \n Support: Core
+                                          (Exact, PathPrefix) \n Support: Implementation-specific
+                                          (RegularExpression)"
+                                        enum:
+                                        - Exact
+                                        - PathPrefix
+                                        - RegularExpression
+                                        type: string
+                                      value:
+                                        default: /
+                                        description: Value of the HTTP path to match
+                                          against.
+                                        maxLength: 1024
+                                        type: string
+                                    type: object
+                                  queryParams:
+                                    description: 'QueryParams specifies HTTP query
+                                      parameter matchers. Multiple match values are
+                                      ANDed together, meaning, a request must match
+                                      all the specified query parameters to select
+                                      the route. Supported list: - Istio: https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest
+                                      - MSE Ingress: https://help.aliyun.com/zh/ack/ack-managed-and-ack-dedicated/user-guide/annotations-supported-by-mse-ingress-gateways-1
+                                      Header/Cookie > QueryParams - Gateway API'
+                                    items:
+                                      description: HTTPQueryParamMatch describes how
+                                        to select a HTTP route by matching HTTP query
+                                        parameters.
+                                      properties:
+                                        name:
+                                          description: "Name is the name of the HTTP
+                                            query param to be matched. This must be
+                                            an exact string match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                            \n If multiple entries specify equivalent
+                                            query param names, only the first entry
+                                            with an equivalent name MUST be considered
+                                            for a match. Subsequent entries with an
+                                            equivalent query param name MUST be ignored.
+                                            \n If a query param is repeated in an
+                                            HTTP request, the behavior is purposely
+                                            left undefined, since different data planes
+                                            have different capabilities. However,
+                                            it is *recommended* that implementations
+                                            should match against the first value of
+                                            the param if the data plane supports it,
+                                            as this behavior is expected in other
+                                            load balancing contexts outside of the
+                                            Gateway API. \n Users SHOULD NOT route
+                                            traffic based on repeated query params
+                                            to guard themselves against potential
+                                            differences in the implementations."
+                                          maxLength: 256
+                                          minLength: 1
+                                          pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          type: string
+                                        type:
+                                          default: Exact
+                                          description: "Type specifies how to match
+                                            against the value of the query parameter.
+                                            \n Support: Extended (Exact) \n Support:
+                                            Implementation-specific (RegularExpression)
+                                            \n Since RegularExpression QueryParamMatchType
+                                            has Implementation-specific conformance,
+                                            implementations can support POSIX, PCRE
+                                            or any other dialects of regular expressions.
+                                            Please read the implementation's documentation
+                                            to determine the supported dialect."
+                                          enum:
+                                          - Exact
+                                          - RegularExpression
+                                          type: string
+                                        value:
+                                          description: Value is the value of HTTP
+                                            query param to be matched.
+                                          maxLength: 1024
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    maxItems: 16
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                type: object
+                              type: array
+                            pause:
+                              description: Pause defines a pause stage for a rollout,
+                                manual or auto
+                              properties:
+                                duration:
+                                  description: Duration the amount of time to wait
+                                    before moving to the next step.
+                                  format: int32
+                                  type: integer
+                              type: object
+                            replicas:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Replicas is the number of expected canary
+                                pods in this batch it can be an absolute number (ex:
+                                5) or a percentage of total pods.'
+                              x-kubernetes-int-or-string: true
+                            requestHeaderModifier:
+                              description: "Set overwrites the request with the given
+                                header (name, value) before the action. \n Input:
+                                GET /foo HTTP/1.1 my-header: foo \n requestHeaderModifier:
+                                set: - name: \"my-header\" value: \"bar\" \n Output:
+                                GET /foo HTTP/1.1 my-header: bar"
+                              properties:
+                                add:
+                                  description: "Add adds the given header(s) (name,
+                                    value) to the request before the action. It appends
+                                    to any existing values associated with the header
+                                    name. \n Input: GET /foo HTTP/1.1 my-header: foo
+                                    \n Config: add: - name: \"my-header\" value: \"bar,baz\"
+                                    \n Output: GET /foo HTTP/1.1 my-header: foo,bar,baz"
+                                  items:
+                                    description: HTTPHeader represents an HTTP Header
+                                      name and value as defined by RFC 7230.
+                                    properties:
+                                      name:
+                                        description: "Name is the name of the HTTP
+                                          Header to be matched. Name matching MUST
+                                          be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                          \n If multiple entries specify equivalent
+                                          header names, the first entry with an equivalent
+                                          name MUST be considered for a match. Subsequent
+                                          entries with an equivalent header name MUST
+                                          be ignored. Due to the case-insensitivity
+                                          of header names, \"foo\" and \"Foo\" are
+                                          considered equivalent."
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      value:
+                                        description: Value is the value of HTTP Header
+                                          to be matched.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 16
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                remove:
+                                  description: "Remove the given header(s) from the
+                                    HTTP request before the action. The value of Remove
+                                    is a list of HTTP header names. Note that the
+                                    header names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                    \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
+                                    bar my-header3: baz \n Config: remove: [\"my-header1\",
+                                    \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
+                                    bar"
+                                  items:
+                                    type: string
+                                  maxItems: 16
+                                  type: array
+                                set:
+                                  description: "Set overwrites the request with the
+                                    given header (name, value) before the action.
+                                    \n Input: GET /foo HTTP/1.1 my-header: foo \n
+                                    Config: set: - name: \"my-header\" value: \"bar\"
+                                    \n Output: GET /foo HTTP/1.1 my-header: bar"
+                                  items:
+                                    description: HTTPHeader represents an HTTP Header
+                                      name and value as defined by RFC 7230.
+                                    properties:
+                                      name:
+                                        description: "Name is the name of the HTTP
+                                          Header to be matched. Name matching MUST
+                                          be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                          \n If multiple entries specify equivalent
+                                          header names, the first entry with an equivalent
+                                          name MUST be considered for a match. Subsequent
+                                          entries with an equivalent header name MUST
+                                          be ignored. Due to the case-insensitivity
+                                          of header names, \"foo\" and \"Foo\" are
+                                          considered equivalent."
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      value:
+                                        description: Value is the value of HTTP Header
+                                          to be matched.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 16
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                            traffic:
+                              description: Traffic indicate how many percentage of
+                                traffic the canary pods should receive Value is of
+                                string type and is a percentage, e.g. 5%.
+                              type: string
+                          type: object
+                        type: array
+                      trafficRoutingRef:
+                        description: TrafficRoutingRef is TrafficRouting's Name
+                        type: string
+                      trafficRoutings:
+                        description: TrafficRoutings support ingress, gateway api
+                          and custom network resource(e.g. istio, apisix) to enable
+                          more fine-grained traffic routing and current only support
+                          one TrafficRouting
+                        items:
+                          description: TrafficRoutingRef hosts all the different configuration
+                            for supported service meshes to enable more fine-grained
+                            traffic routing
+                          properties:
+                            customNetworkRefs:
+                              description: CustomNetworkRefs hold a list of custom
+                                providers to route traffic
+                              items:
+                                description: ObjectRef holds a references to the Kubernetes
+                                  object
+                                properties:
+                                  apiVersion:
+                                    description: API Version of the referent
+                                    type: string
+                                  kind:
+                                    description: Kind of the referent
+                                    type: string
+                                  name:
+                                    description: Name of the referent
+                                    type: string
+                                required:
+                                - apiVersion
+                                - kind
+                                - name
+                                type: object
+                              type: array
+                            gateway:
+                              description: Gateway holds Gateway specific configuration
+                                to route traffic Gateway configuration only supports
+                                >= v0.4.0 (v1alpha2).
+                              properties:
+                                httpRouteName:
+                                  description: HTTPRouteName refers to the name of
+                                    an `HTTPRoute` resource in the same namespace
+                                    as the `Rollout`
+                                  type: string
+                              type: object
+                            gracePeriodSeconds:
+                              default: 3
+                              description: Optional duration in seconds the traffic
+                                provider(e.g. nginx ingress controller) consumes the
+                                service, ingress configuration changes gracefully.
+                              format: int32
+                              type: integer
+                            ingress:
+                              description: Ingress holds Ingress specific configuration
+                                to route traffic, e.g. Nginx, Alb.
+                              properties:
+                                classType:
+                                  description: ClassType refers to the type of `Ingress`.
+                                    current support nginx, aliyun-alb. default is
+                                    nginx.
+                                  type: string
+                                name:
+                                  description: Name refers to the name of an `Ingress`
+                                    resource in the same namespace as the `Rollout`
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            service:
+                              description: Service holds the name of a service which
+                                selects pods with stable version and don't select
+                                any pods with canary version.
+                              type: string
+                          required:
+                          - service
+                          type: object
+                        type: array
+                    type: object
+                  canary:
+                    description: CanaryStrategy defines parameters for a Replica Based
+                      Canary
+                    properties:
+                      disableGenerateCanaryService:
+                        description: canary service will not be generated if DisableGenerateCanaryService
+                          is true
+                        type: boolean
+                      enableExtraWorkloadForCanary:
+                        description: 'If true, then it will create new deployment
+                          for canary, such as: workload-demo-canary. When user verifies
+                          that the canary version is ready, we will remove the canary
+                          deployment and release the deployment workload-demo in full.
+                          Current only support k8s native deployment'
+                        type: boolean
+                      failureThreshold:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: FailureThreshold indicates how many failed pods
+                          can be tolerated in all upgraded pods. Only when FailureThreshold
+                          are satisfied, Rollout can enter ready state. If FailureThreshold
+                          is nil, Rollout will use the MaxUnavailable of workload
+                          as its FailureThreshold. Defaults to nil.
+                        x-kubernetes-int-or-string: true
+                      patchPodTemplateMetadata:
+                        description: PatchPodTemplateMetadata indicates patch configuration(e.g.
+                          labels, annotations) to the canary deployment podTemplateSpec.metadata
+                          only support for canary deployment
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: labels
+                            type: object
+                        type: object
+                      steps:
+                        description: Steps define the order of phases to execute release
+                          in batches(20%, 40%, 60%, 80%, 100%)
+                        items:
+                          description: CanaryStep defines a step of a canary workload.
+                          properties:
+                            matches:
+                              description: "Matches define conditions used for matching
+                                incoming HTTP requests to the canary service. Each
+                                match is independent, i.e. this rule will be matched
+                                as long as **any** one of the matches is satisfied.
+                                \n It cannot support Traffic (weight-based routing)
+                                and Matches simultaneously, if both are configured.
+                                In such cases, Matches takes precedence."
+                              items:
+                                properties:
+                                  headers:
+                                    description: Headers specifies HTTP request header
+                                      matchers. Multiple match values are ANDed together,
+                                      meaning, a request must match all the specified
+                                      headers to select the route.
+                                    items:
+                                      description: HTTPHeaderMatch describes how to
+                                        select a HTTP route by matching HTTP request
+                                        headers.
+                                      properties:
+                                        name:
+                                          description: "Name is the name of the HTTP
+                                            Header to be matched. Name matching MUST
+                                            be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                            \n If multiple entries specify equivalent
+                                            header names, only the first entry with
+                                            an equivalent name MUST be considered
+                                            for a match. Subsequent entries with an
+                                            equivalent header name MUST be ignored.
+                                            Due to the case-insensitivity of header
+                                            names, \"foo\" and \"Foo\" are considered
+                                            equivalent. \n When a header is repeated
+                                            in an HTTP request, it is implementation-specific
+                                            behavior as to how this is represented.
+                                            Generally, proxies should follow the guidance
+                                            from the RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                            regarding processing a repeated header,
+                                            with special handling for \"Set-Cookie\"."
+                                          maxLength: 256
+                                          minLength: 1
+                                          pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          type: string
+                                        type:
+                                          default: Exact
+                                          description: "Type specifies how to match
+                                            against the value of the header. \n Support:
+                                            Core (Exact) \n Support: Implementation-specific
+                                            (RegularExpression) \n Since RegularExpression
+                                            HeaderMatchType has implementation-specific
+                                            conformance, implementations can support
+                                            POSIX, PCRE or any other dialects of regular
+                                            expressions. Please read the implementation's
+                                            documentation to determine the supported
+                                            dialect."
+                                          enum:
+                                          - Exact
+                                          - RegularExpression
+                                          type: string
+                                        value:
+                                          description: Value is the value of HTTP
+                                            Header to be matched.
+                                          maxLength: 4096
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    maxItems: 16
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  path:
+                                    description: 'Path specifies a HTTP request path
+                                      matcher. Supported list: - Istio: https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest
+                                      - GatewayAPI: If path is defined, the whole
+                                      HttpRouteMatch will be used as a standalone
+                                      matcher'
+                                    properties:
+                                      type:
+                                        default: PathPrefix
+                                        description: "Type specifies how to match
+                                          against the path Value. \n Support: Core
+                                          (Exact, PathPrefix) \n Support: Implementation-specific
+                                          (RegularExpression)"
+                                        enum:
+                                        - Exact
+                                        - PathPrefix
+                                        - RegularExpression
+                                        type: string
+                                      value:
+                                        default: /
+                                        description: Value of the HTTP path to match
+                                          against.
+                                        maxLength: 1024
+                                        type: string
+                                    type: object
+                                  queryParams:
+                                    description: 'QueryParams specifies HTTP query
+                                      parameter matchers. Multiple match values are
+                                      ANDed together, meaning, a request must match
+                                      all the specified query parameters to select
+                                      the route. Supported list: - Istio: https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest
+                                      - MSE Ingress: https://help.aliyun.com/zh/ack/ack-managed-and-ack-dedicated/user-guide/annotations-supported-by-mse-ingress-gateways-1
+                                      Header/Cookie > QueryParams - Gateway API'
+                                    items:
+                                      description: HTTPQueryParamMatch describes how
+                                        to select a HTTP route by matching HTTP query
+                                        parameters.
+                                      properties:
+                                        name:
+                                          description: "Name is the name of the HTTP
+                                            query param to be matched. This must be
+                                            an exact string match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                            \n If multiple entries specify equivalent
+                                            query param names, only the first entry
+                                            with an equivalent name MUST be considered
+                                            for a match. Subsequent entries with an
+                                            equivalent query param name MUST be ignored.
+                                            \n If a query param is repeated in an
+                                            HTTP request, the behavior is purposely
+                                            left undefined, since different data planes
+                                            have different capabilities. However,
+                                            it is *recommended* that implementations
+                                            should match against the first value of
+                                            the param if the data plane supports it,
+                                            as this behavior is expected in other
+                                            load balancing contexts outside of the
+                                            Gateway API. \n Users SHOULD NOT route
+                                            traffic based on repeated query params
+                                            to guard themselves against potential
+                                            differences in the implementations."
+                                          maxLength: 256
+                                          minLength: 1
+                                          pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          type: string
+                                        type:
+                                          default: Exact
+                                          description: "Type specifies how to match
+                                            against the value of the query parameter.
+                                            \n Support: Extended (Exact) \n Support:
+                                            Implementation-specific (RegularExpression)
+                                            \n Since RegularExpression QueryParamMatchType
+                                            has Implementation-specific conformance,
+                                            implementations can support POSIX, PCRE
+                                            or any other dialects of regular expressions.
+                                            Please read the implementation's documentation
+                                            to determine the supported dialect."
+                                          enum:
+                                          - Exact
+                                          - RegularExpression
+                                          type: string
+                                        value:
+                                          description: Value is the value of HTTP
+                                            query param to be matched.
+                                          maxLength: 1024
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    maxItems: 16
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                type: object
+                              type: array
+                            pause:
+                              description: Pause defines a pause stage for a rollout,
+                                manual or auto
+                              properties:
+                                duration:
+                                  description: Duration the amount of time to wait
+                                    before moving to the next step.
+                                  format: int32
+                                  type: integer
+                              type: object
+                            replicas:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Replicas is the number of expected canary
+                                pods in this batch it can be an absolute number (ex:
+                                5) or a percentage of total pods.'
+                              x-kubernetes-int-or-string: true
+                            requestHeaderModifier:
+                              description: "Set overwrites the request with the given
+                                header (name, value) before the action. \n Input:
+                                GET /foo HTTP/1.1 my-header: foo \n requestHeaderModifier:
+                                set: - name: \"my-header\" value: \"bar\" \n Output:
+                                GET /foo HTTP/1.1 my-header: bar"
+                              properties:
+                                add:
+                                  description: "Add adds the given header(s) (name,
+                                    value) to the request before the action. It appends
+                                    to any existing values associated with the header
+                                    name. \n Input: GET /foo HTTP/1.1 my-header: foo
+                                    \n Config: add: - name: \"my-header\" value: \"bar,baz\"
+                                    \n Output: GET /foo HTTP/1.1 my-header: foo,bar,baz"
+                                  items:
+                                    description: HTTPHeader represents an HTTP Header
+                                      name and value as defined by RFC 7230.
+                                    properties:
+                                      name:
+                                        description: "Name is the name of the HTTP
+                                          Header to be matched. Name matching MUST
+                                          be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                          \n If multiple entries specify equivalent
+                                          header names, the first entry with an equivalent
+                                          name MUST be considered for a match. Subsequent
+                                          entries with an equivalent header name MUST
+                                          be ignored. Due to the case-insensitivity
+                                          of header names, \"foo\" and \"Foo\" are
+                                          considered equivalent."
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      value:
+                                        description: Value is the value of HTTP Header
+                                          to be matched.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 16
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                remove:
+                                  description: "Remove the given header(s) from the
+                                    HTTP request before the action. The value of Remove
+                                    is a list of HTTP header names. Note that the
+                                    header names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                    \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
+                                    bar my-header3: baz \n Config: remove: [\"my-header1\",
+                                    \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
+                                    bar"
+                                  items:
+                                    type: string
+                                  maxItems: 16
+                                  type: array
+                                set:
+                                  description: "Set overwrites the request with the
+                                    given header (name, value) before the action.
+                                    \n Input: GET /foo HTTP/1.1 my-header: foo \n
+                                    Config: set: - name: \"my-header\" value: \"bar\"
+                                    \n Output: GET /foo HTTP/1.1 my-header: bar"
+                                  items:
+                                    description: HTTPHeader represents an HTTP Header
+                                      name and value as defined by RFC 7230.
+                                    properties:
+                                      name:
+                                        description: "Name is the name of the HTTP
+                                          Header to be matched. Name matching MUST
+                                          be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                          \n If multiple entries specify equivalent
+                                          header names, the first entry with an equivalent
+                                          name MUST be considered for a match. Subsequent
+                                          entries with an equivalent header name MUST
+                                          be ignored. Due to the case-insensitivity
+                                          of header names, \"foo\" and \"Foo\" are
+                                          considered equivalent."
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      value:
+                                        description: Value is the value of HTTP Header
+                                          to be matched.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 16
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                            traffic:
+                              description: Traffic indicate how many percentage of
+                                traffic the canary pods should receive Value is of
+                                string type and is a percentage, e.g. 5%.
+                              type: string
+                          type: object
+                        type: array
+                      trafficRoutingRef:
+                        description: TrafficRoutingRef is TrafficRouting's Name
+                        type: string
+                      trafficRoutings:
+                        description: TrafficRoutings support ingress, gateway api
+                          and custom network resource(e.g. istio, apisix) to enable
+                          more fine-grained traffic routing and current only support
+                          one TrafficRouting
+                        items:
+                          description: TrafficRoutingRef hosts all the different configuration
+                            for supported service meshes to enable more fine-grained
+                            traffic routing
+                          properties:
+                            customNetworkRefs:
+                              description: CustomNetworkRefs hold a list of custom
+                                providers to route traffic
+                              items:
+                                description: ObjectRef holds a references to the Kubernetes
+                                  object
+                                properties:
+                                  apiVersion:
+                                    description: API Version of the referent
+                                    type: string
+                                  kind:
+                                    description: Kind of the referent
+                                    type: string
+                                  name:
+                                    description: Name of the referent
+                                    type: string
+                                required:
+                                - apiVersion
+                                - kind
+                                - name
+                                type: object
+                              type: array
+                            gateway:
+                              description: Gateway holds Gateway specific configuration
+                                to route traffic Gateway configuration only supports
+                                >= v0.4.0 (v1alpha2).
+                              properties:
+                                httpRouteName:
+                                  description: HTTPRouteName refers to the name of
+                                    an `HTTPRoute` resource in the same namespace
+                                    as the `Rollout`
+                                  type: string
+                              type: object
+                            gracePeriodSeconds:
+                              default: 3
+                              description: Optional duration in seconds the traffic
+                                provider(e.g. nginx ingress controller) consumes the
+                                service, ingress configuration changes gracefully.
+                              format: int32
+                              type: integer
+                            ingress:
+                              description: Ingress holds Ingress specific configuration
+                                to route traffic, e.g. Nginx, Alb.
+                              properties:
+                                classType:
+                                  description: ClassType refers to the type of `Ingress`.
+                                    current support nginx, aliyun-alb. default is
+                                    nginx.
+                                  type: string
+                                name:
+                                  description: Name refers to the name of an `Ingress`
+                                    resource in the same namespace as the `Rollout`
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            service:
+                              description: Service holds the name of a service which
+                                selects pods with stable version and don't select
+                                any pods with canary version.
+                              type: string
+                          required:
+                          - service
+                          type: object
+                        type: array
+                    type: object
+                  paused:
+                    description: Paused indicates that the Rollout is paused. Default
+                      value is false
+                    type: boolean
+                type: object
+              workloadRef:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
+                  WorkloadRef contains enough information to let you identify a workload
+                  for Rollout Batch release of the bypass'
+                properties:
+                  apiVersion:
+                    description: API Version of the referent
+                    type: string
+                  kind:
+                    description: Kind of the referent
+                    type: string
+                  name:
+                    description: Name of the referent
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            required:
+            - strategy
+            - workloadRef
+            type: object
+          status:
+            description: RolloutStatus defines the observed state of Rollout
+            properties:
+              blueGreenStatus:
+                description: BlueGreen describes the state of the blueGreen rollout
+                properties:
+                  currentStepIndex:
+                    description: CurrentStepIndex defines the current step of the
+                      rollout is on.
+                    format: int32
+                    type: integer
+                  currentStepState:
+                    type: string
+                  finalisingStep:
+                    description: FinalisingStep the step of finalising
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  nextStepIndex:
+                    description: NextStepIndex defines the next step of the rollout
+                      is on. In normal case, NextStepIndex is equal to CurrentStepIndex
+                      + 1 If the current step is the last step, NextStepIndex is equal
+                      to -1 Before the release, NextStepIndex is also equal to -1
+                      0 is not used and won't appear in any case It is allowed to
+                      patch NextStepIndex by design, e.g. if CurrentStepIndex is 2,
+                      user can patch NextStepIndex to 3 (if exists) to achieve batch
+                      jump, or patch NextStepIndex to 1 to implement a re-execution
+                      of step 1 Patching it with a non-positive value is useless and
+                      meaningless, which will be corrected in the next reconciliation
+                    format: int32
+                    type: integer
+                  observedRolloutID:
+                    description: ObservedRolloutID will record the newest spec.RolloutID
+                      if status.canaryRevision equals to workload.updateRevision
+                    type: string
+                  observedWorkloadGeneration:
+                    description: observedWorkloadGeneration is the most recent generation
+                      observed for this Rollout ref workload generation.
+                    format: int64
+                    type: integer
+                  podTemplateHash:
+                    description: pod template hash is used as service selector label
+                    type: string
+                  rolloutHash:
+                    description: RolloutHash from rollout.spec object
+                    type: string
+                  stableRevision:
+                    description: StableRevision indicates the revision of stable pods
+                    type: string
+                  updatedReadyReplicas:
+                    description: UpdatedReadyReplicas the numbers of updated ready
+                      pods
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: UpdatedReplicas the numbers of updated pods
+                    format: int32
+                    type: integer
+                  updatedRevision:
+                    description: UpdatedRevision is calculated by rollout based on
+                      podTemplateHash, and the internal logic flow uses It may be
+                      different from rs podTemplateHash in different k8s versions,
+                      so it cannot be used as service selector label
+                    type: string
+                required:
+                - currentStepState
+                - finalisingStep
+                - nextStepIndex
+                - podTemplateHash
+                - updatedReadyReplicas
+                - updatedReplicas
+                - updatedRevision
+                type: object
+              canaryStatus:
+                description: Canary describes the state of the canary rollout
+                properties:
+                  canaryReadyReplicas:
+                    description: CanaryReadyReplicas the numbers of ready canary revision
+                      pods
+                    format: int32
+                    type: integer
+                  canaryReplicas:
+                    description: CanaryReplicas the numbers of canary revision pods
+                    format: int32
+                    type: integer
+                  canaryRevision:
+                    description: CanaryRevision is calculated by rollout based on
+                      podTemplateHash, and the internal logic flow uses It may be
+                      different from rs podTemplateHash in different k8s versions,
+                      so it cannot be used as service selector label
+                    type: string
+                  currentStepIndex:
+                    description: CurrentStepIndex defines the current step of the
+                      rollout is on.
+                    format: int32
+                    type: integer
+                  currentStepState:
+                    type: string
+                  finalisingStep:
+                    description: FinalisingStep the step of finalising
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  nextStepIndex:
+                    description: NextStepIndex defines the next step of the rollout
+                      is on. In normal case, NextStepIndex is equal to CurrentStepIndex
+                      + 1 If the current step is the last step, NextStepIndex is equal
+                      to -1 Before the release, NextStepIndex is also equal to -1
+                      0 is not used and won't appear in any case It is allowed to
+                      patch NextStepIndex by design, e.g. if CurrentStepIndex is 2,
+                      user can patch NextStepIndex to 3 (if exists) to achieve batch
+                      jump, or patch NextStepIndex to 1 to implement a re-execution
+                      of step 1 Patching it with a non-positive value is useless and
+                      meaningless, which will be corrected in the next reconciliation
+                    format: int32
+                    type: integer
+                  observedRolloutID:
+                    description: ObservedRolloutID will record the newest spec.RolloutID
+                      if status.canaryRevision equals to workload.updateRevision
+                    type: string
+                  observedWorkloadGeneration:
+                    description: observedWorkloadGeneration is the most recent generation
+                      observed for this Rollout ref workload generation.
+                    format: int64
+                    type: integer
+                  podTemplateHash:
+                    description: pod template hash is used as service selector label
+                    type: string
+                  rolloutHash:
+                    description: RolloutHash from rollout.spec object
+                    type: string
+                  stableRevision:
+                    description: StableRevision indicates the revision of stable pods
+                    type: string
+                required:
+                - canaryReadyReplicas
+                - canaryReplicas
+                - canaryRevision
+                - currentStepState
+                - finalisingStep
+                - nextStepIndex
+                - podTemplateHash
+                type: object
+              conditions:
+                description: Conditions a list of conditions a rollout can have.
+                items:
+                  description: RolloutCondition describes the state of a rollout at
+                    a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Phase of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of rollout condition.
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentStepIndex:
+                description: These two values will be synchronized with the same fileds
+                  in CanaryStatus or BlueGreeenStatus mainly used to provide info
+                  for kubectl get command
+                format: int32
+                type: integer
+              currentStepState:
+                type: string
+              message:
+                description: Message provides details on why the rollout is in its
+                  current phase
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this Rollout.
+                format: int64
+                type: integer
+              phase:
+                description: BlueGreenStatus *BlueGreenStatus `json:"blueGreenStatus,omitempty"`
+                  Phase is the rollout phase.
+                type: string
+            required:
+            - currentStepIndex
+            - currentStepState
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/versions/kruise-rollout/0.6.2/templates/rollouts.kruise.io_trafficroutings.yaml
+++ b/versions/kruise-rollout/0.6.2/templates/rollouts.kruise.io_trafficroutings.yaml
@@ -1,0 +1,314 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.0
+  creationTimestamp: null
+  name: trafficroutings.rollouts.kruise.io
+spec:
+  group: rollouts.kruise.io
+  names:
+    kind: TrafficRouting
+    listKind: TrafficRoutingList
+    plural: trafficroutings
+    singular: trafficrouting
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The TrafficRouting status phase
+      jsonPath: .status.phase
+      name: STATUS
+      type: string
+    - description: The TrafficRouting canary status message
+      jsonPath: .status.message
+      name: MESSAGE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TrafficRouting is the Schema for the TrafficRoutings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              objectRef:
+                description: ObjectRef indicates trafficRouting ref
+                items:
+                  description: TrafficRoutingRef hosts all the different configuration
+                    for supported service meshes to enable more fine-grained traffic
+                    routing
+                  properties:
+                    customNetworkRefs:
+                      description: CustomNetworkRefs hold a list of custom providers
+                        to route traffic
+                      items:
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - apiVersion
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                    gateway:
+                      description: Gateway holds Gateway specific configuration to
+                        route traffic Gateway configuration only supports >= v0.4.0
+                        (v1alpha2).
+                      properties:
+                        httpRouteName:
+                          description: HTTPRouteName refers to the name of an `HTTPRoute`
+                            resource in the same namespace as the `Rollout`
+                          type: string
+                      type: object
+                    gracePeriodSeconds:
+                      default: 3
+                      description: Optional duration in seconds the traffic provider(e.g.
+                        nginx ingress controller) consumes the service, ingress configuration
+                        changes gracefully.
+                      format: int32
+                      type: integer
+                    ingress:
+                      description: Ingress holds Ingress specific configuration to
+                        route traffic, e.g. Nginx, Alb.
+                      properties:
+                        classType:
+                          description: ClassType refers to the type of `Ingress`.
+                            current support nginx, aliyun-alb. default is nginx.
+                          type: string
+                        name:
+                          description: Name refers to the name of an `Ingress` resource
+                            in the same namespace as the `Rollout`
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    service:
+                      description: Service holds the name of a service which selects
+                        pods with stable version and don't select any pods with canary
+                        version.
+                      type: string
+                  required:
+                  - service
+                  type: object
+                type: array
+              strategy:
+                description: trafficrouting strategy
+                properties:
+                  matches:
+                    description: Matches define conditions used for matching the incoming
+                      HTTP requests to canary service. Each match is independent,
+                      i.e. this rule will be matched if **any** one of the matches
+                      is satisfied. If Gateway API, current only support one match.
+                      And cannot support both weight and matches, if both are configured,
+                      then matches takes precedence.
+                    items:
+                      properties:
+                        headers:
+                          description: Headers specifies HTTP request header matchers.
+                            Multiple match values are ANDed together, meaning, a request
+                            must match all the specified headers to select the route.
+                          items:
+                            description: HTTPHeaderMatch describes how to select a
+                              HTTP route by matching HTTP request headers.
+                            properties:
+                              name:
+                                description: "Name is the name of the HTTP Header
+                                  to be matched. Name matching MUST be case insensitive.
+                                  (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                  \n If multiple entries specify equivalent header
+                                  names, only the first entry with an equivalent name
+                                  MUST be considered for a match. Subsequent entries
+                                  with an equivalent header name MUST be ignored.
+                                  Due to the case-insensitivity of header names, \"foo\"
+                                  and \"Foo\" are considered equivalent. \n When a
+                                  header is repeated in an HTTP request, it is implementation-specific
+                                  behavior as to how this is represented. Generally,
+                                  proxies should follow the guidance from the RFC:
+                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                  regarding processing a repeated header, with special
+                                  handling for \"Set-Cookie\"."
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                type: string
+                              type:
+                                default: Exact
+                                description: "Type specifies how to match against
+                                  the value of the header. \n Support: Core (Exact)
+                                  \n Support: Implementation-specific (RegularExpression)
+                                  \n Since RegularExpression HeaderMatchType has implementation-specific
+                                  conformance, implementations can support POSIX,
+                                  PCRE or any other dialects of regular expressions.
+                                  Please read the implementation's documentation to
+                                  determine the supported dialect."
+                                enum:
+                                - Exact
+                                - RegularExpression
+                                type: string
+                              value:
+                                description: Value is the value of HTTP Header to
+                                  be matched.
+                                maxLength: 4096
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          maxItems: 16
+                          type: array
+                      type: object
+                    type: array
+                  requestHeaderModifier:
+                    description: "Set overwrites the request with the given header
+                      (name, value) before the action. \n Input: GET /foo HTTP/1.1
+                      my-header: foo \n requestHeaderModifier: set: - name: \"my-header\"
+                      value: \"bar\" \n Output: GET /foo HTTP/1.1 my-header: bar"
+                    properties:
+                      add:
+                        description: "Add adds the given header(s) (name, value) to
+                          the request before the action. It appends to any existing
+                          values associated with the header name. \n Input: GET /foo
+                          HTTP/1.1 my-header: foo \n Config: add: - name: \"my-header\"
+                          value: \"bar,baz\" \n Output: GET /foo HTTP/1.1 my-header:
+                          foo,bar,baz"
+                        items:
+                          description: HTTPHeader represents an HTTP Header name and
+                            value as defined by RFC 7230.
+                          properties:
+                            name:
+                              description: "Name is the name of the HTTP Header to
+                                be matched. Name matching MUST be case insensitive.
+                                (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                \n If multiple entries specify equivalent header names,
+                                the first entry with an equivalent name MUST be considered
+                                for a match. Subsequent entries with an equivalent
+                                header name MUST be ignored. Due to the case-insensitivity
+                                of header names, \"foo\" and \"Foo\" are considered
+                                equivalent."
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                              type: string
+                            value:
+                              description: Value is the value of HTTP Header to be
+                                matched.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        maxItems: 16
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      remove:
+                        description: "Remove the given header(s) from the HTTP request
+                          before the action. The value of Remove is a list of HTTP
+                          header names. Note that the header names are case-insensitive
+                          (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                          \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
+                          bar my-header3: baz \n Config: remove: [\"my-header1\",
+                          \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
+                          bar"
+                        items:
+                          type: string
+                        maxItems: 16
+                        type: array
+                      set:
+                        description: "Set overwrites the request with the given header
+                          (name, value) before the action. \n Input: GET /foo HTTP/1.1
+                          my-header: foo \n Config: set: - name: \"my-header\" value:
+                          \"bar\" \n Output: GET /foo HTTP/1.1 my-header: bar"
+                        items:
+                          description: HTTPHeader represents an HTTP Header name and
+                            value as defined by RFC 7230.
+                          properties:
+                            name:
+                              description: "Name is the name of the HTTP Header to
+                                be matched. Name matching MUST be case insensitive.
+                                (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                \n If multiple entries specify equivalent header names,
+                                the first entry with an equivalent name MUST be considered
+                                for a match. Subsequent entries with an equivalent
+                                header name MUST be ignored. Due to the case-insensitivity
+                                of header names, \"foo\" and \"Foo\" are considered
+                                equivalent."
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                              type: string
+                            value:
+                              description: Value is the value of HTTP Header to be
+                                matched.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        maxItems: 16
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  weight:
+                    description: Weight indicate how many percentage of traffic the
+                      canary pods should receive
+                    format: int32
+                    type: integer
+                type: object
+            required:
+            - objectRef
+            - strategy
+            type: object
+          status:
+            properties:
+              message:
+                description: Message provides details on why the rollout is in its
+                  current phase
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this Rollout.
+                format: int64
+                type: integer
+              phase:
+                description: Phase is the trafficRouting phase.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/versions/kruise-rollout/0.6.2/templates/webhookconfiguration.yaml
+++ b/versions/kruise-rollout/0.6.2/templates/webhookconfiguration.yaml
@@ -1,0 +1,258 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kruise-rollout-mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-rollout-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-unified-workload
+    failurePolicy: Fail
+    name: munifiedworload.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
+    {{- if .Values.rollout.webhook.objectSelector }}
+    {{- range $label := .Values.rollout.webhook.objectSelector }}
+        - key: {{ $label.key }}
+          operator: {{ $label.operator }}
+      {{- if $label.values}}
+          values:
+        {{- range $value := $label.values }}
+            - {{ $value }}
+        {{- end }}
+      {{- end}}
+    {{- end }}
+    {{- end }}
+    rules:
+      - apiGroups:
+          - '*'
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - '*'
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-rollout-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-v1-deployment
+    failurePolicy: Fail
+    name: mdeployment.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: control-plane
+          operator: NotIn
+          values:
+            - {{ .Values.rollout.fullname }}
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
+    {{- if .Values.rollout.webhook.objectSelector }}
+    {{- range $label := .Values.rollout.webhook.objectSelector }}
+        - key: {{ $label.key }}
+          operator: {{ $label.operator }}
+      {{- if $label.values}}
+          values:
+        {{- range $value := $label.values }}
+            - {{ $value }}
+        {{- end }}
+      {{- end}}
+    {{- end }}
+    {{- end }}
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - deployments
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-rollout-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-cloneset
+    failurePolicy: Fail
+    name: mcloneset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
+    {{- if .Values.rollout.webhook.objectSelector }}
+    {{- range $label := .Values.rollout.webhook.objectSelector }}
+        - key: {{ $label.key }}
+          operator: {{ $label.operator }}
+      {{- if $label.values}}
+          values:
+        {{- range $value := $label.values }}
+            - {{ $value }}
+        {{- end }}
+      {{- end}}
+    {{- end }}
+    {{- end }}
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - UPDATE
+        resources:
+          - clonesets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-rollout-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-v1-statefulset
+    failurePolicy: Fail
+    name: mstatefulset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
+    {{- if .Values.rollout.webhook.objectSelector }}
+    {{- range $label := .Values.rollout.webhook.objectSelector }}
+        - key: {{ $label.key }}
+          operator: {{ $label.operator }}
+      {{- if $label.values}}
+          values:
+        {{- range $value := $label.values }}
+            - {{ $value }}
+        {{- end }}
+      {{- end}}
+    {{- end }}
+    {{- end }}
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+        resources:
+          - statefulsets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-rollout-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-statefulset
+    failurePolicy: Fail
+    name: madvancedstatefulset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
+    {{- if .Values.rollout.webhook.objectSelector }}
+    {{- range $label := .Values.rollout.webhook.objectSelector }}
+        - key: {{ $label.key }}
+          operator: {{ $label.operator }}
+      {{- if $label.values}}
+          values:
+        {{- range $value := $label.values }}
+            - {{ $value }}
+        {{- end }}
+      {{- end}}
+    {{- end }}
+    {{- end }}
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - statefulsets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-rollout-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-daemonset
+    failurePolicy: Fail
+    name: mdaemonset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
+    {{- if .Values.rollout.webhook.objectSelector }}
+    {{- range $label := .Values.rollout.webhook.objectSelector }}
+        - key: {{ $label.key }}
+          operator: {{ $label.operator }}
+      {{- if $label.values }}
+          values:
+        {{- range $value := $label.values }}
+            - {{ $value }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - UPDATE
+        resources:
+          - daemonsets
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: kruise-rollout-validating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-rollout-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-rollouts-kruise-io-rollout
+    failurePolicy: Fail
+    name: vrollout.kb.io
+    rules:
+      - apiGroups:
+          - rollouts.kruise.io
+        apiVersions:
+          - v1alpha1
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - rollouts
+    sideEffects: None

--- a/versions/kruise-rollout/0.6.2/values.yaml
+++ b/versions/kruise-rollout/0.6.2/values.yaml
@@ -1,0 +1,71 @@
+# Default values for rollout.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# values for rollout installation
+installation:
+  namespace: kruise-rollout
+  createNamespace: true
+
+rollout:
+  fullname: kruise-rollout-controller-manager
+  healthBindPort: "8081"
+  metricsBindAddr: "127.0.0.1:8080"
+  webhook:
+    port: 9876
+    # ObjectSelector for workloads in MutatingWebhookConfiguration, which
+    # allow Rollout operator focuses on the workloads that users really care.
+    objectSelector:
+    #  - key: <your-focused-workload-label-key>
+    #    operator: In # Exists DoesNotExist NotIn
+    #    values:
+    #      - <your-focused-workload-label-values>
+
+
+  log:
+    level: 4
+  featureGates: AdvancedDeployment=true
+
+replicaCount: 2
+
+image:
+  repository: openkruise/kruise-rollout
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: v0.6.1
+imagePullSecrets:
+  # - name: for-your-secret-name
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+
+service:
+  port: 443
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+tolerations:
+# Toleration represents the toleration object that can be attached to a pod.
+# The pod this Toleration is attached to tolerates any taint that matches
+# the triple <key,value,effect> using the matching operator <operator>.
+# you could find more info at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# - effect: NoSchedule
+#   key: test
+#   operator: Equal
+#   value: hello


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

chart v0.6.2 is reformatted v0.6.1, making it can be used by KubeVela

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
