### PR TITLE
Add topologySpreadConstraints for kruise-manager

### DIFF
--- a/versions/kruise/next/templates/manager.yaml
+++ b/versions/kruise/next/templates/manager.yaml
@@ -51,6 +51,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        component: kruise-manager
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -131,7 +132,7 @@ spec:
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
-            control-plane: controller-manager
+            component: kruise-manager
 {{- if and ( eq (int .Capabilities.KubeVersion.Major) 1) ( gt (int .Capabilities.KubeVersion.Minor) 26 ) }}
         matchLabelKeys:
         - pod-template-hash


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
------

Fixes #123 
This patch updates the kruise-controller-manager Deployment to:

- Add a `component: kruise-manager` label to the Pod template
- Change the existing topologySpreadConstraints selector to `matchLabels.component=kruise-manager`

With these changes, manager replicas will be spread across availability zones as specified in the issue.
