### PR TITLE
Rename Service label to control-plane: kruise-controller-manager

### DIFF
--- a/versions/kruise/next/templates/_helpers.tpl
+++ b/versions/kruise/next/templates/_helpers.tpl
@@ -62,7 +62,7 @@ ports:
 - port: 443
   targetPort: {{ .Values.manager.webhook.port }}
 selector:
-  control-plane: controller-manager
+  control-plane: kruise-controller-manager
 {{- end -}}
 
 {{- define "webhookSecretData" -}}

--- a/versions/kruise/next/templates/manager.yaml
+++ b/versions/kruise/next/templates/manager.yaml
@@ -33,14 +33,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: kruise-controller-manager
   name: kruise-controller-manager
   namespace: {{ .Values.installation.namespace }}
 spec:
   replicas: {{ .Values.manager.replicas }}
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: kruise-controller-manager
   minReadySeconds: 3
   strategy:
     type: RollingUpdate
@@ -50,7 +50,7 @@ spec:
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: kruise-controller-manager
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
