### PR TITLE
add Huawei Cloud CCE cluster's EIB and EIP configurations

### DIFF
--- a/versions/kruise-game/next/Chart.yaml
+++ b/versions/kruise-game/next/Chart.yaml
@@ -9,3 +9,4 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - "[Changed]: https://github.com/openkruise/kruise-game/blob/master/CHANGELOG.md"
+    - "[Added]: support Huawei CCE EIB and EIP"

--- a/versions/kruise-game/next/templates/controller_manager_config.yaml
+++ b/versions/kruise-game/next/templates/controller_manager_config.yaml
@@ -20,6 +20,17 @@ data:
     max_port = 1500
     min_port = 1000
 
+    [hwcloud]
+    enable = true
+    [hwcloud.elb]
+    max_port = 700
+    min_port = 500
+    block_ports = []
+    [hwcloud.cce.elb]
+    max_port = 65535
+    min_port = 32768
+    block_ports = []
+
     [volcengine]
     enable = true
     [volcengine.clb]


### PR DESCRIPTION
The code supporting Huawei Cloud CCE cluster's ELB and EIP has been merged(https://github.com/openkruise/kruise-game/pull/261). 

Add Huawei Cloud CCE cluster's ELB and EIP configurations in helm chart.

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
