### PR TITLE
fix: remove creationTimestamp from kruise-rollout

### DIFF
--- a/versions/kruise-rollout/next/templates/rbac_role.yaml
+++ b/versions/kruise-rollout/next/templates/rbac_role.yaml
@@ -64,7 +64,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: kruise-rollout-manager-role
 rules:
   - apiGroups:

--- a/versions/kruise-rollout/next/templates/rollouts.kruise.io_rollouthistories.yaml
+++ b/versions/kruise-rollout/next/templates/rollouts.kruise.io_rollouthistories.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.0
-  creationTimestamp: null
   name: rollouthistories.rollouts.kruise.io
 spec:
   group: rollouts.kruise.io

--- a/versions/kruise-rollout/next/templates/rollouts.kruise.io_trafficroutings.yaml
+++ b/versions/kruise-rollout/next/templates/rollouts.kruise.io_trafficroutings.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.0
-  creationTimestamp: null
   name: trafficroutings.rollouts.kruise.io
 spec:
   group: rollouts.kruise.io

--- a/versions/kruise-rollout/next/templates/webhookconfiguration.yaml
+++ b/versions/kruise-rollout/next/templates/webhookconfiguration.yaml
@@ -231,7 +231,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: kruise-rollout-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:


### PR DESCRIPTION
kubeconform rejects 'creationTimestamp: null' because the field expects a timestamp string, not null. This is a controller-gen artifact that should be stripped from Helm chart templates.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
