### PR TITLE
fix: add missing configmaps permissions for sandbox controller

### DIFF
--- a/versions/kruise-agents-sandbox-controller/next/templates/rbac.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/rbac.yaml
@@ -67,6 +67,14 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - events
     verbs:
       - create


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Note: This PR only updates `versions/kruise-agents-sandbox-controller/next`, so it does not bump a released chart version or update the released chart changelog.



### What happened

The sandbox controller logs RBAC errors when listing ConfigMaps at cluster scope:

`configmaps is forbidden: cannot list resource "configmaps" in API group "" at the cluster scope`

### What changed

Add `get/list/watch` permissions for core `configmaps` to the sandbox controller ClusterRole.

### Validation

- `helm lint versions/kruise-agents-sandbox-controller/next`
- `helm template cnap-kruise-agents versions/kruise-agents-sandbox-controller/next --show-only templates/rbac.yaml`