### PR TITLE
feat(sandbox-controller): expose /metrics via Service and add metrics…

### DIFF
--- a/versions/kruise-agents-sandbox-controller/next/templates/deployment.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/deployment.yaml
@@ -49,7 +49,16 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           name: manager
-          ports: [ ]
+          ports:
+            - name: https-metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            - name: https-webhook
+              containerPort: {{ .Values.webhook.port }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ .Values.healthProbe.port }}
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /readyz

--- a/versions/kruise-agents-sandbox-controller/next/templates/rbac.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/rbac.yaml
@@ -219,4 +219,45 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "sandbox-controller.serviceAccountName" . }}
     namespace: {{ include "sandbox-controller.namespace" . }}
+---
+# auth-delegator binding: required for controller-runtime's
+# --metrics-secure=true filter (WithAuthenticationAndAuthorization), which
+# delegates TokenReview/SubjectAccessReview to kube-apiserver. Without this,
+# every scrape against https://.../metrics returns 401.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "sandbox-controller.fullname" . }}-auth-delegator
+  labels:
+    {{- include "sandbox-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sandbox-controller.serviceAccountName" . }}
+    namespace: {{ include "sandbox-controller.namespace" . }}
+{{- if .Values.metrics.rbac.create }}
+---
+# Metrics reader role: grants permission to scrape /metrics on the
+# secured endpoint. Bind this to your Prometheus / ARMS scraper SA, e.g.:
+#
+#   kubectl create clusterrolebinding sandbox-controller-metrics-reader \
+#     --clusterrole={{ include "sandbox-controller.fullname" . }}-metrics-reader \
+#     --serviceaccount=monitoring:prometheus
+#
+# Or use `kubectl get --raw` from an account that already holds this role.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "sandbox-controller.fullname" . }}-metrics-reader
+  labels:
+    {{- include "sandbox-controller.labels" . | nindent 4 }}
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+{{- end }}
 {{- end }}

--- a/versions/kruise-agents-sandbox-controller/next/templates/service.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/service.yaml
@@ -7,8 +7,13 @@ metadata:
     {{- include "sandbox-controller.labels" . | nindent 4 }}
 spec:
   ports:
-    - port: 443
+    - name: https-webhook
+      port: 443
       protocol: TCP
       targetPort: {{ .Values.webhook.port }}
+    - name: https-metrics
+      port: {{ .Values.metrics.port }}
+      protocol: TCP
+      targetPort: {{ .Values.metrics.port }}
   selector:
     {{- include "sandbox-controller.selectorLabels" . | nindent 4 }}

--- a/versions/kruise-agents-sandbox-controller/next/values.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/values.yaml
@@ -14,7 +14,16 @@ webhook:
 
 # Metrics configuration
 metrics:
+  # Port the controller binds for the Prometheus /metrics endpoint.
+  # Served over HTTPS with authn/authz delegation to kube-apiserver
+  # (controller-runtime's --metrics-secure=true default).
   port: 8443
+  rbac:
+    # Create a ClusterRole that grants `get` on the /metrics nonResourceURL.
+    # Bind it to your Prometheus / ARMS scraper ServiceAccount to allow
+    # scraping the HTTPS endpoint. Disable if you manage metrics RBAC
+    # outside this chart.
+    create: true
 
 # Health probe configuration
 healthProbe:


### PR DESCRIPTION
… RBAC

The controller binds Prometheus /metrics on :8443 but the chart never exposed that port through a Service, so users following the standard 'kubectl get --raw /api/v1/namespaces/sandbox-system/services/<svc>:8443/proxy/metrics' pattern got nothing. Same Service is now used to terminate both webhook (443) and metrics (8443) traffic.

- service.yaml: add named port 'https-metrics' targeting containerPort 8443; rename the existing webhook port to 'https-webhook' so kube-prometheus ServiceMonitor selectors work.
- deployment.yaml: declare named containerPorts for metrics, webhook and the health probe so the spec is no longer 'ports: [ ]'.
- rbac.yaml:
  * Add ClusterRoleBinding to system:auth-delegator so the controller-runtime --metrics-secure filter (WithAuthenticationAndAuthorization) can issue TokenReview and SubjectAccessReview against kube-apiserver. Without it, every scrape returns 401.
  * Add an opt-in <name>-metrics-reader ClusterRole (verb: get on nonResourceURLs: /metrics) that operators bind to their scraper ServiceAccount. Controlled by .Values.metrics.rbac.create (default true).
- values.yaml: document metrics.port and add metrics.rbac.create toggle with comments.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
