### PR TITLE
feat(sandbox-controller): add agent runtime injection config

### DIFF
--- a/versions/kruise-agents-sandbox-controller/next/Chart.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/Chart.yaml
@@ -4,7 +4,7 @@ description: The Helm chart for Agents Sandbox Controller
 
 type: application
 
-version: 0.3.0
+version: 0.6.0
 
 appVersion: "v0.3.0"
 
@@ -17,4 +17,5 @@ keywords:
   - openkruise
 annotations:
   artifacthub.io/changes: |
+    - "[Added]: support injecting the agent-runtime native sidecar via the agent-runtime entry of the sandbox-injection-config ConfigMap"
     - "[Changed]: https://github.com/openkruise/agents/blob/master/CHANGELOG.md"

--- a/versions/kruise-agents-sandbox-controller/next/README.md
+++ b/versions/kruise-agents-sandbox-controller/next/README.md
@@ -33,6 +33,9 @@ The following table lists the configurable parameters of the agents-sandbox-cont
 | `nodeSelector`               | Node selector for Pod scheduling          | `{}`                                                                                                                    |
 | `tolerations`                | Tolerations for Pod scheduling            | `[]`                                                                                                                    |
 | `affinity`                   | Affinity for Pod scheduling               | `{}`                                                                                                                    |
+| `agentRuntime.image.repository` | Injected agent-runtime sidecar image repository | `openkruise/agent-runtime` |
+| `agentRuntime.image.tag` | Injected agent-runtime sidecar image tag | `v0.3.0` |
+| `agentRuntime.image.pullPolicy` | Injected agent-runtime sidecar image pull policy | `IfNotPresent` |
 | `agentio.trafficProxy.controlPlaneNamespace` | Namespace containing the Agentio control plane | `agentio-system` |
 | `agentio.trafficProxy.controlPlaneService` | Agentio control-plane Service name | `agentiod` |
 | `agentio.trafficProxy.xdsAddress` | Explicit XDS address; generated from service and namespace when empty | `""` |
@@ -49,6 +52,54 @@ The following table lists the configurable parameters of the agents-sandbox-cont
 The `sandbox-injection-config` ConfigMap is installed in the sandbox-controller
 release namespace. `controlPlaneNamespace` is independent, so the injected
 traffic proxy can connect to Agentio running in another namespace.
+
+## Agent Runtime Injection
+
+The `sandbox-injection-config` ConfigMap also ships an `agent-runtime` entry.
+It is applied only to sandboxes that explicitly opt in by declaring the runtime
+in `Sandbox.spec.runtimes`:
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: demo
+spec:
+  runtimes:
+    - name: agent-runtime
+  # ... pod template
+```
+
+When the runtime is declared, the controller injects:
+
+- A native sidecar container named `agent-runtime`, built from
+  `agentRuntime.image.repository`, `agentRuntime.image.tag` and
+  `agentRuntime.image.pullPolicy`. The default is the public image
+  `openkruise/agent-runtime:v0.3.0`. The sidecar carries its own `ENVD_DIR`
+  environment variable and mounts `envd-volume` at `/mnt/envd`.
+- `ENVD_DIR`, `GODEBUG` and `POD_UID` environment variables, the `envd-volume`
+  (`/mnt/envd`) mount, and a `postStart` hook into the first business container.
+- One `emptyDir` volume named `envd-volume`, shared by the sidecar and the first
+  business container.
+
+### Requirements
+
+- **Kubernetes >= 1.29.** The `agent-runtime` container is injected as a native
+  sidecar (an init container with `restartPolicy: Always`), which requires the
+  `SidecarContainers` feature to be enabled by default. On older clusters the
+  injected pod will be rejected or the sidecar will not restart as expected.
+- **The first business container image must contain `bash`.** The injected
+  `postStart` hook runs `bash /mnt/envd/envd-run.sh` inside that container, so
+  images without a `bash` binary (for example plain `distroless` or `busybox`
+  based images) will fail to start.
+
+### Not included
+
+This chart intentionally ships only the `traffic-proxy` and `agent-runtime`
+injection entries. The **TLS / helper runtime** and the **CSI runtime** are
+**not** included: no CSI driver, no `AGENT_IDENTITY` settings or certificates,
+and no additional RBAC, Deployment, Service or CRD resources are created for
+them. Deploy those components separately if your environment needs them.
 
 Specify each parameter using the `--set key=value[,key=value]` argument. For example:
 

--- a/versions/kruise-agents-sandbox-controller/next/README.md
+++ b/versions/kruise-agents-sandbox-controller/next/README.md
@@ -34,7 +34,7 @@ The following table lists the configurable parameters of the agents-sandbox-cont
 | `tolerations`                | Tolerations for Pod scheduling            | `[]`                                                                                                                    |
 | `affinity`                   | Affinity for Pod scheduling               | `{}`                                                                                                                    |
 | `agentRuntime.image.repository` | Injected agent-runtime sidecar image repository | `openkruise/agent-runtime` |
-| `agentRuntime.image.tag` | Injected agent-runtime sidecar image tag | `v0.3.0` |
+| `agentRuntime.image.tag` | Injected agent-runtime sidecar image tag | `v0.2.0` |
 | `agentRuntime.image.pullPolicy` | Injected agent-runtime sidecar image pull policy | `IfNotPresent` |
 | `agentio.trafficProxy.controlPlaneNamespace` | Namespace containing the Agentio control plane | `agentio-system` |
 | `agentio.trafficProxy.controlPlaneService` | Agentio control-plane Service name | `agentiod` |
@@ -75,7 +75,7 @@ When the runtime is declared, the controller injects:
 - A native sidecar container named `agent-runtime`, built from
   `agentRuntime.image.repository`, `agentRuntime.image.tag` and
   `agentRuntime.image.pullPolicy`. The default is the public image
-  `openkruise/agent-runtime:v0.3.0`. The sidecar carries its own `ENVD_DIR`
+  `openkruise/agent-runtime:v0.2.0`. The sidecar carries its own `ENVD_DIR`
   environment variable and mounts `envd-volume` at `/mnt/envd`.
 - `ENVD_DIR`, `GODEBUG` and `POD_UID` environment variables, the `envd-volume`
   (`/mnt/envd`) mount, and a `postStart` hook into the first business container.

--- a/versions/kruise-agents-sandbox-controller/next/templates/sandbox-injection-config.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/sandbox-injection-config.yaml
@@ -288,3 +288,73 @@ data:
         }
       ]
     }
+  agent-runtime: |
+    {
+      "mainContainer": {
+        "env": [
+          {
+            "name": "ENVD_DIR",
+            "value": "/mnt/envd"
+          },
+          {
+            "name": "GODEBUG",
+            "value": "multipathtcp=0"
+          },
+          {
+            "name": "POD_UID",
+            "valueFrom": {
+              "fieldRef": {
+                "apiVersion": "v1",
+                "fieldPath": "metadata.uid"
+              }
+            }
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/mnt/envd",
+            "name": "envd-volume"
+          }
+        ],
+        "lifecycle": {
+          "postStart": {
+            "exec": {
+              "command": [
+                "bash",
+                "/mnt/envd/envd-run.sh"
+              ]
+            }
+          }
+        }
+      },
+      "csiSidecar": [
+        {
+          "command": [
+            "sh",
+            "/workspace/entrypoint.sh"
+          ],
+          "env": [
+            {
+              "name": "ENVD_DIR",
+              "value": "/mnt/envd"
+            }
+          ],
+          "image": {{ printf "%s:%s" .Values.agentRuntime.image.repository .Values.agentRuntime.image.tag | quote }},
+          "imagePullPolicy": {{ .Values.agentRuntime.image.pullPolicy | quote }},
+          "name": "agent-runtime",
+          "restartPolicy": "Always",
+          "volumeMounts": [
+            {
+              "mountPath": "/mnt/envd",
+              "name": "envd-volume"
+            }
+          ]
+        }
+      ],
+      "volume": [
+        {
+          "emptyDir": {},
+          "name": "envd-volume"
+        }
+      ]
+    }

--- a/versions/kruise-agents-sandbox-controller/next/templates/sandbox-injection-config.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/sandbox-injection-config.yaml
@@ -314,6 +314,14 @@ data:
           {
             "mountPath": "/mnt/envd",
             "name": "envd-volume"
+          },
+          {
+            "mountPath": "/var/run/agent-runtime",
+            "name": "agent-runtime-state"
+          },
+          {
+            "mountPath": "/var/run/agent-helper",
+            "name": "agent-helper"
           }
         ],
         "lifecycle": {
@@ -337,6 +345,22 @@ data:
             {
               "name": "ENVD_DIR",
               "value": "/mnt/envd"
+            },
+            {
+              "name": "RUNTIME_MODE",
+              "value": "helper"
+            },
+            {
+              "name": "HELPER_SOCKET",
+              "value": "/var/run/agent-helper/helper.sock"
+            },
+            {
+              "name": "AGENT_RUNTIME_PORT",
+              "value": "49985"
+            },
+            {
+              "name": "ENVD_URL",
+              "value": "http://127.0.0.1:49983"
             }
           ],
           "image": {{ printf "%s:%s" .Values.agentRuntime.image.repository .Values.agentRuntime.image.tag | quote }},
@@ -347,6 +371,14 @@ data:
             {
               "mountPath": "/mnt/envd",
               "name": "envd-volume"
+            },
+            {
+              "mountPath": "/var/run/agent-runtime",
+              "name": "agent-runtime-state"
+            },
+            {
+              "mountPath": "/var/run/agent-helper",
+              "name": "agent-helper"
             }
           ]
         }
@@ -355,6 +387,14 @@ data:
         {
           "emptyDir": {},
           "name": "envd-volume"
+        },
+        {
+          "emptyDir": {},
+          "name": "agent-runtime-state"
+        },
+        {
+          "emptyDir": {},
+          "name": "agent-helper"
         }
       ]
     }

--- a/versions/kruise-agents-sandbox-controller/next/values.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/values.yaml
@@ -79,6 +79,15 @@ tolerations: [ ]
 
 affinity: { }
 
+# Agent runtime injection configuration.
+# Used by the `agent-runtime` entry of the sandbox-injection-config ConfigMap,
+# which is injected when a Sandbox declares the `agent-runtime` runtime.
+agentRuntime:
+  image:
+    repository: openkruise/agent-runtime
+    tag: v0.3.0
+    pullPolicy: IfNotPresent
+
 # BEGIN GENERATED AGENTIO TRAFFIC PROXY VALUES - DO NOT EDIT
 agentio:
   trafficProxy:

--- a/versions/kruise-agents-sandbox-controller/next/values.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/values.yaml
@@ -85,7 +85,7 @@ affinity: { }
 agentRuntime:
   image:
     repository: openkruise/agent-runtime
-    tag: v0.3.0
+    tag: v0.2.0
     pullPolicy: IfNotPresent
 
 # BEGIN GENERATED AGENTIO TRAFFIC PROXY VALUES - DO NOT EDIT


### PR DESCRIPTION
## Summary
- add the opt-in `agent-runtime` injection entry to `sandbox-injection-config`
- expose the public agent-runtime image settings and document native-sidecar requirements
- release the sandbox-controller chart as version 0.6.0 without CSI or identity resources

## Test plan
- [x] `helm lint versions/kruise-agents-sandbox-controller/next`
- [x] Rendered `templates/sandbox-injection-config.yaml` with Helm and parsed both ConfigMap payloads as JSON
- [ ] `./scripts/lint.sh` (not run: Docker is unavailable in this environment)