### PR TITLE
sync(agents): align next charts with agents config

### DIFF
--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_checkpoints.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_checkpoints.yaml
@@ -12,92 +12,97 @@ spec:
     listKind: CheckpointList
     plural: checkpoints
     shortNames:
-      - cp
+    - cp
     singular: checkpoint
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.phase
-          name: Status
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Checkpoint is the Schema for the Checkpoints API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec defines the desired state of Checkpoint
-              properties:
-                keepRunning:
-                  description: |-
-                    KeepRunning indicates whether the pod remains in the Running state after passing the checkpoint.
-                    Default is true.
-                  type: boolean
-                persistentContents:
-                  description: 'PersistentContents indicates resume pod with persistent
-                  content, Enum: memory, filesystem'
-                  items:
-                    type: string
-                  type: array
-                  x-kubernetes-list-type: atomic
-                podName:
-                  description: PodName is checkpoint podName.
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Checkpoint is the Schema for the Checkpoints API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Checkpoint
+            properties:
+              keepRunning:
+                description: |-
+                  KeepRunning indicates whether the pod remains in the Running state after passing the checkpoint.
+                  Default is true.
+                type: boolean
+              persistentContents:
+                description: 'PersistentContents indicates resume pod with persistent
+                  content, Enum: podInfo, memory, filesystem'
+                items:
                   type: string
-                sandboxName:
-                  description: SandboxName is checkpoint sandboxName.
-                  type: string
-                ttlAfterFinished:
-                  description: 'valid format: 30s, 30m, 30d'
-                  type: string
-              type: object
-            status:
-              description: status defines the observed state of Checkpoint
-              properties:
-                checkpointId:
-                  description: checkpoint-id
-                  type: string
-                completionTime:
-                  description: CompletionTime is checkpoint completed time, and phase
-                    is Succeeded or Failed.
-                  format: date-time
-                  type: string
-                message:
-                  description: message
-                  type: string
-                observedGeneration:
-                  description: |-
-                    observedGeneration is the most recent generation observed for this Checkpoint. It corresponds to the
-                    Checkpoint's generation, which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-                phase:
-                  description: Checkpoint Phase
-                  type: string
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: { }
+                type: array
+                x-kubernetes-list-type: atomic
+              podName:
+                description: PodName is checkpoint podName.
+                type: string
+              sandboxName:
+                description: SandboxName is checkpoint sandboxName.
+                type: string
+              ttlAfterFinished:
+                description: 'valid format: 30s, 30m, 30d'
+                type: string
+            type: object
+          status:
+            description: status defines the observed state of Checkpoint
+            properties:
+              checkpointId:
+                description: checkpoint-id
+                type: string
+              completionTime:
+                description: CompletionTime is checkpoint completed time, and phase
+                  is Succeeded or Failed.
+                format: date-time
+                type: string
+              message:
+                description: message
+                type: string
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recent generation observed for this Checkpoint. It corresponds to the
+                  Checkpoint's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              phase:
+                description: Checkpoint Phase
+                type: string
+              podTemplateDelta:
+                description: |-
+                  PodTemplateDelta stores a Strategic Merge Patch that captures the delta between
+                  the running Pod at pause time and the base Pod generated from sandbox.spec.template
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_commits.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_commits.yaml
@@ -1,0 +1,210 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: commits.agents.kruise.io
+spec:
+  group: agents.kruise.io
+  names:
+    kind: Commit
+    listKind: CommitList
+    plural: commits
+    shortNames:
+    - cmt
+    singular: commit
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time to live
+      jsonPath: .spec.ttl
+      name: TTL
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              containerName:
+                type: string
+                x-kubernetes-validations:
+                - message: containerName is immutable
+                  rule: self == oldSelf
+              image:
+                type: string
+                x-kubernetes-validations:
+                - message: image is immutable
+                  rule: self == oldSelf
+              podName:
+                type: string
+                x-kubernetes-validations:
+                - message: podName is immutable
+                  rule: self == oldSelf
+              registryAuth:
+                description: |-
+                  RegistryAuth specifies credentials for pushing the committed image.
+                  If nil, the commit will attempt an anonymous push.
+                properties:
+                  credentials:
+                    additionalProperties:
+                      type: string
+                    description: Credentials is reserved for future use. Currently
+                      has no effect.
+                    type: object
+                  secrets:
+                    description: Secrets is a list of dockerconfigjson Secret names
+                      in the same namespace.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              squashLayer:
+                default: 0
+                description: |-
+                  SquashLayer is the max number of writable layers to keep after squashing.
+                  0 means no squashing. Reserved for future implementation.
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: squashLayer is immutable
+                  rule: self == oldSelf
+              timeoutSeconds:
+                default: 0
+                description: |-
+                  TimeoutSeconds is the max duration (in seconds) for the commit job.
+                  Exceeded jobs are terminated and marked Failed. 0 means no timeout.
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: timeoutSeconds is immutable
+                  rule: self == oldSelf
+              ttl:
+                description: |-
+                  TtlAfterFinished is how long the Commit is retained after reaching a terminal phase.
+                  The controller auto-deletes the Commit once TTL expires. Nil means no auto-deletion.
+                type: string
+            required:
+            - containerName
+            - image
+            - podName
+            type: object
+          status:
+            default:
+              phase: Pending
+            properties:
+              commitID:
+                type: string
+              completionTime:
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  conditions represent the current state of the Commit resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              phase:
+                default: Pending
+                enum:
+                - Pending
+                - Running
+                - Succeeded
+                - Failed
+                type: string
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - phase
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_poolautoscalers.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_poolautoscalers.yaml
@@ -1,0 +1,340 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: poolautoscalers.agents.kruise.io
+spec:
+  group: agents.kruise.io
+  names:
+    kind: PoolAutoscaler
+    listKind: PoolAutoscalerList
+    plural: poolautoscalers
+    shortNames:
+    - pa
+    singular: poolautoscaler
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.scaleTargetRef.name
+      name: Reference
+      type: string
+    - jsonPath: .spec.minReplicas
+      name: MinReplicas
+      type: integer
+    - jsonPath: .spec.maxReplicas
+      name: MaxReplicas
+      type: integer
+    - jsonPath: .status.currentReplicas
+      name: CurrentReplicas
+      type: integer
+    - jsonPath: .status.desiredReplicas
+      name: DesiredReplicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          PoolAutoscaler is the configuration for a warming pool autoscaler,
+          which automatically manages the replica count of the warming pool
+          based on the policies specified.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired behavior of the autoscaler.
+            properties:
+              capacityPolicy:
+                description: CapacityPolicy defines the capacity configuration of
+                  the target resource pool.
+                properties:
+                  scaleDown:
+                    description: ScaleDown is the scaling rule for scaling down.
+                    properties:
+                      stabilizationWindowSeconds:
+                        description: |-
+                          StabilizationWindowSeconds is the cooldown period after any scale action before
+                          a scale in this direction is allowed. This is a cooldown model: the first scale
+                          action is immediate, subsequent actions must wait for the window to elapse since
+                          the most recent scale action (in either direction).
+                          Must be >= 60 and <= 3600 (one hour) when set.
+                          Scale-up defaults to 60 seconds when omitted and is normalized at runtime to at
+                          least the process-wide Sandbox Pending timeout plus 10 seconds.
+                          Scale-down defaults to 300 seconds when omitted.
+                        format: int32
+                        maximum: 3600
+                        minimum: 60
+                        type: integer
+                    type: object
+                  scaleUp:
+                    description: ScaleUp is the scaling rule for scaling up.
+                    properties:
+                      stabilizationWindowSeconds:
+                        description: |-
+                          StabilizationWindowSeconds is the cooldown period after any scale action before
+                          a scale in this direction is allowed. This is a cooldown model: the first scale
+                          action is immediate, subsequent actions must wait for the window to elapse since
+                          the most recent scale action (in either direction).
+                          Must be >= 60 and <= 3600 (one hour) when set.
+                          Scale-up defaults to 60 seconds when omitted and is normalized at runtime to at
+                          least the process-wide Sandbox Pending timeout plus 10 seconds.
+                          Scale-down defaults to 300 seconds when omitted.
+                        format: int32
+                        maximum: 3600
+                        minimum: 60
+                        type: integer
+                    type: object
+                  targetAvailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      TargetAvailable is the desired available replicas.
+                      Can be an absolute number (ex: 5) or a percentage of current replicas (ex: 70%).
+                      When the pool is empty, a percentage target is bootstrapped against
+                      maxReplicas so the pool can seed its initial idle capacity.
+                    x-kubernetes-int-or-string: true
+                  tolerance:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      Tolerance is the tolerance between the watermark and desired value under which
+                      no updates are made to the desired number of replicas.
+                      Can be an absolute number (ex: 5) or a percentage (ex: 10%).
+                      If not set, defaults to 10%.
+                      A percentage tolerance is always resolved against the target value:
+                      when targetAvailable is also a percentage, both percentages are combined
+                      first and applied to the pool size; when targetAvailable is an absolute
+                      number, the percentage tolerance is applied to that resolved target
+                      (e.g. targetAvailable=5 with tolerance=10% yields watermarks [4, 6]).
+                    x-kubernetes-int-or-string: true
+                required:
+                - targetAvailable
+                type: object
+              cronPolicies:
+                description: |-
+                  CronPolicies is a list of potential cron scaling policies which can be used during scaling.
+                  When both CronPolicies and CapacityPolicy are set, CronPolicies takes higher priority.
+                items:
+                  description: CronScalingPolicy defines the cron-based scaling configuration
+                    for the resource pool.
+                  properties:
+                    name:
+                      description: Name is used to specify the scaling policy.
+                      type: string
+                    schedule:
+                      description: |-
+                        Schedule is a cron expression that defines when this policy should be executed.
+                        Supports standard cron format with 5 fields (minute hour day month weekday).
+                      type: string
+                    targetReplicas:
+                      description: TargetReplicas is the desired replicas when this
+                        policy executes.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    timeZone:
+                      description: |-
+                        TimeZone is the time zone name for the given schedule, e.g. "Asia/Shanghai", "UTC".
+                        If not specified, this will default to the time zone of the autoscaler controller manager process.
+                      type: string
+                  required:
+                  - name
+                  - schedule
+                  - targetReplicas
+                  type: object
+                type: array
+              maxReplicas:
+                description: |-
+                  MaxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
+                  It cannot be less than minReplicas.
+                format: int32
+                minimum: 1
+                type: integer
+              minReplicas:
+                default: 0
+                description: |-
+                  MinReplicas is the lower limit for the number of replicas to which the autoscaler
+                  can scale down. It defaults to 0 pods.
+                format: int32
+                minimum: 0
+                type: integer
+              scaleTargetRef:
+                description: |-
+                  ScaleTargetRef points to the target warming pool to scale, and is used to select the pods for which instance status
+                  should be collected, as well as to actually change the replica count.
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    enum:
+                    - SandboxSet
+                    type: string
+                  name:
+                    description: 'Name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend subsequent executions.
+                  Defaults to false.
+                type: boolean
+            required:
+            - maxReplicas
+            - scaleTargetRef
+            type: object
+            x-kubernetes-validations:
+            - message: minReplicas must not be greater than maxReplicas
+              rule: self.minReplicas <= self.maxReplicas
+          status:
+            description: Status is the current information about the autoscaler.
+            properties:
+              appliedCronPolicies:
+                description: AppliedCronPolicies is the execution status of cron policies.
+                items:
+                  description: CronScalingPolicyStatus records the last schedule time
+                    for a cron policy.
+                  properties:
+                    lastScheduleTime:
+                      description: LastScheduleTime is the last time the policy was
+                        successfully scheduled.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the cron policy name.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              conditions:
+                description: Conditions is the set of conditions required for this
+                  autoscaler to scale its target.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentCapacity:
+                description: CurrentCapacity is the last read state of the capacity
+                  used by this autoscaler.
+                properties:
+                  available:
+                    description: Available is current number of available pods managed
+                      by this autoscaler.
+                    format: int32
+                    type: integer
+                required:
+                - available
+                type: object
+              currentReplicas:
+                description: CurrentReplicas is current number of replicas of pods
+                  managed by this autoscaler.
+                format: int32
+                type: integer
+              desiredReplicas:
+                description: DesiredReplicas is the desired number of replicas of
+                  pods managed by this autoscaler.
+                format: int32
+                type: integer
+              lastScaleTime:
+                description: LastScaleTime is the last time the PoolAutoscaler scaled
+                  the number of pods.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by this autoscaler.
+                format: int64
+                type: integer
+              suspended:
+                description: Suspended indicates whether the autoscaler is currently
+                  suspended.
+                type: boolean
+            required:
+            - currentReplicas
+            - desiredReplicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxclaims.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxclaims.yaml
@@ -12,315 +12,327 @@ spec:
     listKind: SandboxClaimList
     plural: sandboxclaims
     shortNames:
-      - sbc
+    - sbc
     singular: sandboxclaim
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.phase
-          name: Phase
-          type: string
-        - jsonPath: .spec.templateName
-          name: Template
-          type: string
-        - jsonPath: .spec.replicas
-          name: Desired
-          type: integer
-        - jsonPath: .status.claimedReplicas
-          name: Claimed
-          type: integer
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: SandboxClaim is the Schema for the sandboxclaims API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec defines the desired state of SandboxClaim
-              properties:
-                annotations:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    Annotations contains key-value pairs to be added as annotations
-                    to claimed Sandbox resources
-                  type: object
-                  x-kubernetes-map-type: granular
-                claimTimeout:
-                  default: 1m
-                  description: |-
-                    ClaimTimeout specifies the maximum duration to wait for claiming sandboxes
-                    If the timeout is reached, the claim will be marked as Completed regardless of
-                    whether all replicas were successfully claimed
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.templateName
+      name: Template
+      type: string
+    - jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - jsonPath: .status.claimedReplicas
+      name: Claimed
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SandboxClaim is the Schema for the sandboxclaims API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of SandboxClaim
+            properties:
+              annotations:
+                additionalProperties:
                   type: string
-                  x-kubernetes-validations:
-                    - message: claimTimeout must be at least 1 second
-                      rule: duration(self) >= duration('1s')
-                createOnNoStock:
-                  default: true
-                  description: CreateOnNoStock allows to create new sandbox if no stock
-                    available
-                  type: boolean
-                dynamicVolumesMount:
-                  description: DynamicVolumesMount specifies the dynamic volumes to
-                    be mounted into the sandbox
-                  items:
-                    properties:
-                      mountID:
-                        type: string
-                      mountPath:
-                        type: string
-                      pvName:
-                        type: string
-                      readOnly:
-                        type: boolean
-                      subPath:
-                        type: string
-                    required:
-                      - mountPath
-                      - pvName
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - mountPath
-                  x-kubernetes-list-type: map
-                envVars:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    EnvVars contains environment variables to be injected into the sandbox
-                    These will be passed to the sandbox's init endpoint (envd) after claiming
-                    Only applicable if the SandboxSet has envd enabled
-                  type: object
-                  x-kubernetes-map-type: granular
-                inplaceUpdate:
-                  description: InplaceUpdate allows to perform inplace update for sandbox
-                    while claiming
+                description: |-
+                  Annotations contains key-value pairs to be added as annotations
+                  to claimed Sandbox resources
+                type: object
+                x-kubernetes-map-type: granular
+              claimTimeout:
+                default: 1m
+                description: |-
+                  ClaimTimeout specifies the maximum duration to wait for claiming sandboxes
+                  If the timeout is reached, the claim will be marked as Completed regardless of
+                  whether all replicas were successfully claimed
+                type: string
+                x-kubernetes-validations:
+                - message: claimTimeout must be at least 1 second
+                  rule: duration(self) >= duration('1s')
+              createOnNoStock:
+                default: true
+                description: CreateOnNoStock allows to create new sandbox if no stock
+                  available
+                type: boolean
+              dynamicVolumesMount:
+                description: DynamicVolumesMount specifies the dynamic volumes to
+                  be mounted into the sandbox
+                items:
                   properties:
-                    image:
-                      description: Image specifies the new image to update to.
-                      type: string
-                    resources:
-                      description: Resources specifies in-place resource update options.
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits specifies the target resource limits for each container.
-                            Only CPU is supported for now. The container's original limit must already be set;
-                            otherwise the value is ignored.
-                            The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests specifies the target resource requests for each container.
-                            Only CPU is supported for now. The container's original request must already be set;
-                            otherwise the value is ignored.
-                            The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
-                          type: object
+                    attributes:
+                      additionalProperties:
+                        type: string
                       type: object
+                    mountID:
+                      type: string
+                    mountPath:
+                      type: string
+                    pvName:
+                      type: string
+                    readOnly:
+                      type: boolean
+                    subPath:
+                      type: string
+                  required:
+                  - mountPath
+                  - pvName
                   type: object
-                labels:
-                  additionalProperties:
+                type: array
+                x-kubernetes-list-map-keys:
+                - mountPath
+                x-kubernetes-list-type: map
+              envVars:
+                additionalProperties:
+                  type: string
+                description: |-
+                  EnvVars contains environment variables to be injected into the sandbox
+                  These will be passed to the sandbox's init endpoint (envd) after claiming
+                  Only applicable if the SandboxSet has envd enabled
+                type: object
+                x-kubernetes-map-type: granular
+              inplaceUpdate:
+                description: InplaceUpdate allows to perform inplace update for sandbox
+                  while claiming
+                properties:
+                  image:
+                    description: Image specifies the new image to update to.
                     type: string
-                  description: |-
-                    Labels contains key-value pairs to be added as labels
-                    to claimed Sandbox resources and synced to sandbox template labels.
+                  resources:
+                    description: Resources specifies in-place resource update options.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits specifies the target resource limits for each container.
+                          Only CPU and memory are supported; other resource names are rejected.
+                          The container's original limit must already be set; otherwise the value is ignored.
+                          A limit must not be lower than the target request of the same resource.
+                          Memory may only be increased: a target lower than the container's current memory is rejected.
+                          Memory resize may restart the container when the pod template declares
+                          resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.
+                          The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests specifies the target resource requests for each container.
+                          Only CPU and memory are supported; other resource names are rejected.
+                          The container's original request must already be set; otherwise the value is ignored.
+                          A request must not exceed the target limit of the same resource.
+                          Memory may only be increased: a target lower than the container's current memory is rejected.
+                          Memory resize may restart the container when the pod template declares
+                          resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.
+                          The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
+                        type: object
+                    type: object
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Labels contains key-value pairs to be added as labels
+                  to claimed Sandbox resources and synced to sandbox template labels.
+                type: object
+                x-kubernetes-map-type: granular
+              replicas:
+                default: 1
+                description: |-
+                  Replicas specifies how many sandboxes to claim (default: 1)
+                  For batch claiming support
+                  This field is immutable once set
+                format: int32
+                minimum: 1
+                type: integer
+                x-kubernetes-validations:
+                - message: replicas is immutable
+                  rule: self == oldSelf
+              reserveFailedSandbox:
+                description: Set ReserveFailedSandbox to true to reserve failed sandboxes
+                type: boolean
+              runtimes:
+                description: Runtimes - Runtime configuration for sandbox object
+                items:
+                  properties:
+                    name:
+                      type: string
+                  required:
+                  - name
                   type: object
-                  x-kubernetes-map-type: granular
-                replicas:
-                  default: 1
-                  description: |-
-                    Replicas specifies how many sandboxes to claim (default: 1)
-                    For batch claiming support
-                    This field is immutable once set
-                  format: int32
-                  minimum: 1
-                  type: integer
-                  x-kubernetes-validations:
-                    - message: replicas is immutable
-                      rule: self == oldSelf
-                reserveFailedSandbox:
-                  description: Set ReserveFailedSandbox to true to reserve failed sandboxes
-                  type: boolean
-                runtimes:
-                  description: Runtimes - Runtime configuration for sandbox object
-                  items:
-                    properties:
-                      name:
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                  x-kubernetes-list-type: atomic
-                shutdownTime:
-                  description: |-
-                    ShutdownTime specifies the absolute time when the sandbox should be shut down
-                    This will be set as spec.shutdownTime (absolute time) on the Sandbox
-                  format: date-time
-                  type: string
-                skipInitRuntime:
-                  default: false
-                  description: SkipInitRuntime allows to skip init runtime for sandbox
-                    while claiming
-                  type: boolean
-                templateName:
-                  description: TemplateName specifies which SandboxSet pool to claim
-                    from
-                  type: string
-                ttlAfterCompleted:
-                  default: 60m
-                  description: |-
-                    TTLAfterCompleted specifies the time to live after the claim reaches Completed phase
-                    After this duration, the SandboxClaim will be automatically deleted.
-                    Note: Only the SandboxClaim resource will be deleted; the claimed sandboxes will NOT be deleted
-                    Set to a negative value (e.g., "-1s") to disable automatic deletion (never delete).
-                  type: string
-                waitReadyTimeout:
-                  default: 30s
-                  description: |-
-                    WaitReadyTimeout specifies the maximum duration for waiting claimed sandbox ready. Default: 30s.
-                    A waiting happens when an inplace update happens, a new sandbox created, etc.
-                    Format: duration string (e.g., "3h", "200s", "15m")
-                  type: string
-                  x-kubernetes-validations:
-                    - message: waitReadyTimeout must be at least 1 second
-                      rule: duration(self) >= duration('1s')
-              required:
-                - templateName
-              type: object
-            status:
-              description: status defines the observed state of SandboxClaim
-              properties:
-                claimStartTime:
-                  description: |-
-                    ClaimStartTime is the timestamp when claiming started
-                    Used for calculating timeout
-                  format: date-time
-                  type: string
-                claimedReplicas:
-                  description: |-
-                    ClaimedReplicas indicates how many sandboxes are currently claimed (total)
-                    This is determined by querying sandboxes with matching ownerReference
-                    Only updated during Pending and Claiming phases
-                  format: int32
-                  type: integer
-                completionTime:
-                  description: |-
-                    CompletionTime is the timestamp when the claim reached Completed phase
-                    Used for TTL calculation
-                  format: date-time
-                  type: string
-                conditions:
-                  description: Conditions represent the current state of the SandboxClaim
-                  items:
-                    description: Condition contains details for one aspect of the current
-                      state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                message:
-                  description: Message provides human-readable details about the current
-                    phase
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed
-                  format: int64
-                  type: integer
-                phase:
-                  description: |-
-                    Phase represents the current phase of the claim
-                    Claiming: In the process of claiming sandboxes
-                    Completed: Claim process finished (either all replicas claimed or timeout reached)
-                  type: string
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: { }
+                type: array
+                x-kubernetes-list-type: atomic
+              shutdownTime:
+                description: |-
+                  ShutdownTime specifies the absolute time when the sandbox should be shut down
+                  This will be set as spec.shutdownTime (absolute time) on the Sandbox
+                format: date-time
+                type: string
+              skipInitRuntime:
+                default: false
+                description: SkipInitRuntime allows to skip init runtime for sandbox
+                  while claiming
+                type: boolean
+              templateName:
+                description: TemplateName specifies which SandboxSet pool to claim
+                  from
+                type: string
+              ttlAfterCompleted:
+                default: 60m
+                description: |-
+                  TTLAfterCompleted specifies the time to live after the claim reaches Completed phase
+                  After this duration, the SandboxClaim will be automatically deleted.
+                  Note: Only the SandboxClaim resource will be deleted; the claimed sandboxes will NOT be deleted
+                  Set to a negative value (e.g., "-1s") to disable automatic deletion (never delete).
+                type: string
+              waitReadyTimeout:
+                default: 30s
+                description: |-
+                  WaitReadyTimeout specifies the maximum duration for waiting claimed sandbox ready. Default: 30s.
+                  A waiting happens when an inplace update happens, a new sandbox created, etc.
+                  Format: duration string (e.g., "3h", "200s", "15m")
+                type: string
+                x-kubernetes-validations:
+                - message: waitReadyTimeout must be at least 1 second
+                  rule: duration(self) >= duration('1s')
+            required:
+            - templateName
+            type: object
+          status:
+            description: status defines the observed state of SandboxClaim
+            properties:
+              claimStartTime:
+                description: |-
+                  ClaimStartTime is the timestamp when claiming started
+                  Used for calculating timeout
+                format: date-time
+                type: string
+              claimedReplicas:
+                description: |-
+                  ClaimedReplicas indicates how many sandboxes are currently claimed (total)
+                  This is determined by querying sandboxes with matching ownerReference
+                  Only updated during Pending and Claiming phases
+                format: int32
+                type: integer
+              completionTime:
+                description: |-
+                  CompletionTime is the timestamp when the claim reached Completed phase
+                  Used for TTL calculation
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions represent the current state of the SandboxClaim
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              message:
+                description: Message provides human-readable details about the current
+                  phase
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  Phase represents the current phase of the claim
+                  Claiming: In the process of claiming sandboxes
+                  Completed: Claim process finished (either all replicas claimed or timeout reached)
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxes.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxes.yaml
@@ -12,307 +12,634 @@ spec:
     listKind: SandboxList
     plural: sandboxes
     shortNames:
-      - sbx
+    - sbx
     singular: sandbox
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.phase
-          name: Status
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .metadata.labels.agents\.kruise\.io/sandbox-claimed
-          name: Claimed
-          type: string
-        - jsonPath: .spec.shutdownTime
-          name: shutdown_time
-          type: string
-        - jsonPath: .spec.pauseTime
-          name: pause_time
-          type: string
-        - jsonPath: .status.message
-          name: Message
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Sandbox is the Schema for the sandboxes API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec defines the desired state of Sandbox
-              properties:
-                lifecycle:
-                  description: Lifecycle defines lifecycle hooks for sandbox upgrade.
-                  properties:
-                    postUpgrade:
-                      description: |-
-                        PostUpgrade is the action executed after the upgrade.
-                        It is typically used to restore workspace data.
-                      properties:
-                        exec:
-                          description: |-
-                            Exec specifies the command to execute inside the sandbox via envd.
-                            The first element is the command, the rest are args.
-                            For shell scripts, use: ["/bin/bash", "-c", "your-script"]
-                          properties:
-                            command:
-                              description: |-
-                                Command is the command line to execute inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                a shell, you need to explicitly call out to that shell.
-                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          type: object
-                        timeoutSeconds:
-                          default: 60
-                          description: TimeoutSeconds is the timeout for the action
-                            execution in seconds.
-                          format: int32
-                          type: integer
-                      type: object
-                    preUpgrade:
-                      description: |-
-                        PreUpgrade is the action executed before the upgrade.
-                        It is typically used to backup workspace data.
-                      properties:
-                        exec:
-                          description: |-
-                            Exec specifies the command to execute inside the sandbox via envd.
-                            The first element is the command, the rest are args.
-                            For shell scripts, use: ["/bin/bash", "-c", "your-script"]
-                          properties:
-                            command:
-                              description: |-
-                                Command is the command line to execute inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                a shell, you need to explicitly call out to that shell.
-                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          type: object
-                        timeoutSeconds:
-                          default: 60
-                          description: TimeoutSeconds is the timeout for the action
-                            execution in seconds.
-                          format: int32
-                          type: integer
-                      type: object
-                  type: object
-                pauseTime:
-                  description: PauseTime - Absolute time when the sandbox will be paused
-                    automatically.
-                  format: date-time
-                  type: string
-                paused:
-                  description: Paused indicates whether pause the sandbox pod.
-                  type: boolean
-                persistentContents:
-                  description: 'PersistentContents indicates resume pod with persistent
-                  content, Enum: ip, memory, filesystem'
-                  items:
-                    type: string
-                  type: array
-                  x-kubernetes-list-type: atomic
-                runtimes:
-                  description: Runtimes - Runtime configuration for sandbox object
-                  items:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .metadata.labels.agents\.kruise\.io/sandbox-claimed
+      name: Claimed
+      type: string
+    - jsonPath: .spec.shutdownTime
+      name: shutdown_time
+      type: string
+    - jsonPath: .spec.pauseTime
+      name: pause_time
+      type: string
+    - jsonPath: .status.recycledCount
+      name: RecycledCount
+      type: integer
+    - jsonPath: .status.message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Sandbox is the Schema for the sandboxes API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Sandbox
+            properties:
+              autoPausePolicy:
+                description: |-
+                  AutoPausePolicy defines pause/resume decision rules based on probe
+                  Conditions. Probes are defined in Spec.Probes.
+                properties:
+                  pause:
+                    description: Pause defines the pause policy for the sandbox.
                     properties:
-                      name:
-                        type: string
-                    required:
-                      - name
+                      whenProbedIdleState:
+                        description: |-
+                          WhenProbedIdleState pauses the sandbox when a probe's Condition message
+                          matches MessageRegex for at least ThresholdDuration.
+                        properties:
+                          messageRegex:
+                            description: |-
+                              MessageRegex is a regular expression matched against the probe's
+                              Condition message (stdout). When the message matches, the Agent is
+                              considered inactive. When it does not match, the Agent is considered
+                              active and the sandbox stays Running.
+                            type: string
+                          probe:
+                            description: |-
+                              Probe is the name of the probe to evaluate for pause decisions.
+                              Must match a probe name in Spec.Probes.
+                            type: string
+                          thresholdDuration:
+                            description: |-
+                              ThresholdDuration is the minimum time the probe's Condition message
+                              must continuously match MessageRegex before the sandbox is paused.
+                              Measured from the Condition's lastTransitionTime.
+
+                              It is required: pausing as soon as a single probe report matches would
+                              drop the smoothing this rule exists for, so there is no meaningful
+                              default and an unset value is a misconfiguration rather than
+                              "pause immediately".
+                            type: string
+                        required:
+                        - messageRegex
+                        - probe
+                        - thresholdDuration
+                        type: object
                     type: object
-                  type: array
-                  x-kubernetes-list-type: atomic
-                shutdownTime:
-                  description: |-
-                    ShutdownTime - Absolute time when the sandbox is deleted.
-                    If a time in the past is provided, the sandbox will be deleted immediately.
-                  format: date-time
+                  resume:
+                    description: Resume defines the resume policy for the sandbox.
+                    properties:
+                      whenProbedScheduleTime:
+                        description: |-
+                          WhenProbedScheduleTime resumes the sandbox before a scheduled task
+                          by parsing the probe's Condition message as a timestamp.
+                        properties:
+                          leadTime:
+                            default: 5m
+                            description: |-
+                              LeadTime is the duration before the parsed timestamp at which the
+                              sandbox should be resumed. For example, if the probe reports the
+                              next scheduled task at time T and LeadTime is 5m, the sandbox is
+                              resumed at T - 5m.
+                            type: string
+                          probe:
+                            description: |-
+                              Probe is the name of the probe to evaluate for resume decisions.
+                              Must match a probe name in Spec.Probes.
+                            type: string
+                          timeFormat:
+                            default: unix
+                            description: |-
+                              TimeFormat indicates the format of the probe's Condition message for
+                              parsing as a timestamp, and defaults to "unix":
+
+                                unix     - seconds since epoch, e.g. "1787040000"
+                                datetime - RFC3339 with offset, e.g. "2026-08-29T08:00:00+08:00"
+
+                              NextResumeTime is set to the parsed timestamp minus LeadTime.
+                            enum:
+                            - unix
+                            - datetime
+                            type: string
+                        required:
+                        - probe
+                        type: object
+                    type: object
+                type: object
+              lifecycle:
+                description: Lifecycle defines lifecycle hooks for sandbox.
+                properties:
+                  postUpgrade:
+                    description: |-
+                      PostUpgrade is the action executed after the upgrade.
+                      It is typically used to restore workspace data.
+                    properties:
+                      exec:
+                        description: |-
+                          Exec specifies the command to execute inside the sandbox via envd.
+                          The first element is the command, the rest are args.
+                          For shell scripts, use: ["/bin/bash", "-c", "your-script"]
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      timeoutSeconds:
+                        default: 60
+                        description: TimeoutSeconds is the timeout for the action
+                          execution in seconds.
+                        format: int32
+                        type: integer
+                    type: object
+                  preUpgrade:
+                    description: |-
+                      PreUpgrade is the action executed before the upgrade.
+                      It is typically used to backup workspace data.
+                    properties:
+                      exec:
+                        description: |-
+                          Exec specifies the command to execute inside the sandbox via envd.
+                          The first element is the command, the rest are args.
+                          For shell scripts, use: ["/bin/bash", "-c", "your-script"]
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      timeoutSeconds:
+                        default: 60
+                        description: TimeoutSeconds is the timeout for the action
+                          execution in seconds.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+              pauseStrategy:
+                description: PauseStrategy configures how a sandbox is paused when
+                  spec.paused is true.
+                properties:
+                  hibernateStrategy:
+                    description: |-
+                      HibernateStrategy configures the storage medium for hibernate state.
+                      Only effective when Type is Hibernate.
+                    properties:
+                      type:
+                        description: Type selects the storage medium for hibernate
+                          state.
+                        type: string
+                    type: object
+                  type:
+                    description: Type selects the pause mechanism.
+                    enum:
+                    - Stop
+                    - Hibernate
+                    type: string
+                type: object
+              pauseTime:
+                description: PauseTime - Absolute time when the sandbox will be paused
+                  automatically.
+                format: date-time
+                type: string
+              paused:
+                description: Paused indicates whether pause the sandbox pod.
+                type: boolean
+              persistentContents:
+                description: 'PersistentContents indicates resume pod with persistent
+                  content, Enum: ip, memory, filesystem'
+                items:
                   type: string
-                template:
+                type: array
+                x-kubernetes-list-type: atomic
+              probes:
+                description: |-
+                  Probes defines a list of named probes that run periodically while the sandbox
+                  is Running. Each probe writes its result to a Pod Status Condition with
+                  type "agents.kruise.io/<name>". Probes are generic — their semantics (e.g.,
+                  "activity detection" vs "cron task detection") are defined by
+                  AutoPausePolicy.Pause/Resume, not by the probe itself.
+
+                  Probe execution is delegated to the agent-runtime sidecar via the
+                  PodProbeMarker Serverless protocol (kruise.io/podprobe annotation).
+                  The controller reads results from Pod.Status.Conditions and mirrors
+                  them to SandboxStatus.Conditions for observability.
+                items:
                   description: |-
-                    Template describes the pods that will be created.
-                    Template is mutual exclusive with TemplateRef
-                  x-kubernetes-preserve-unknown-fields: true
-                templateRef:
-                  description: TemplateRef references a SandboxTemplate, which will
-                    be used to create the sandbox.
+                    Probe defines a named probe that writes its result to a Pod Condition.
+                    Embeds corev1.Probe inline so that exec/periodSeconds/timeoutSeconds/etc.
+                    are directly accessible. Currently only exec probes are supported;
+                    other corev1.Probe fields (httpGet, tcpSocket, grpc) may be supported
+                    in the future as needed.
                   properties:
-                    apiVersion:
+                    containerName:
                       description: |-
-                        name of the SandboxTemplate apiVersion
-                        Default to v1
+                        ContainerName specifies which container to execute the probe in.
+                        If empty, defaults to the first container in the pod spec.
                       type: string
-                    kind:
+                    exec:
+                      description: Exec specifies a command to execute in the container.
+                      properties:
+                        command:
+                          description: |-
+                            Command is the command line to execute inside the container, the working directory for the
+                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                            a shell, you need to explicitly call out to that shell.
+                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    failureThreshold:
                       description: |-
-                        name of the SandboxTemplate kind
-                        Default to PodTemplate
-                      type: string
+                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                        Defaults to 3. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies a GRPC HealthCheckRequest.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          default: ""
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies an HTTP GET request to perform.
+                      properties:
+                        host:
+                          description: |-
+                            Host name to connect to, defaults to the pod IP. You probably want to set
+                            "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: |-
+                                  The header field name.
+                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Name or number of the port to access on the container.
+                            Number must be in the range 1 to 65535.
+                            Name must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host.
+                            Defaults to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: |-
+                        Number of seconds after the container has started before liveness probes are initiated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      format: int32
+                      type: integer
                     name:
-                      description: name of the SandboxTemplate
+                      description: |-
+                        Name is the unique identifier for this probe within the sandbox.
+                        Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      type: string
+                    periodSeconds:
+                      description: |-
+                        How often (in seconds) to perform the probe.
+                        Default to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: |-
+                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies a connection to a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Number or name of the port to access on the container.
+                            Number must be in the range 1 to 65535.
+                            Name must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: |-
+                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                        The grace period is the duration in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your process.
+                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                        value overrides the value provided by the pod spec.
+                        Value must be non-negative integer. The value zero indicates stop immediately via
+                        the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: |-
+                        Number of seconds after which the probe times out.
+                        Defaults to 1 second. Minimum value is 1.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              runtimes:
+                description: Runtimes - Runtime configuration for sandbox object
+                items:
+                  properties:
+                    name:
                       type: string
                   required:
-                    - name
+                  - name
                   type: object
-                upgradePolicy:
-                  description: UpgradePolicy defines the upgrade strategy for the sandbox.
+                type: array
+                x-kubernetes-list-type: atomic
+              shutdownTime:
+                description: |-
+                  ShutdownTime - Absolute time when the sandbox is deleted.
+                  If a time in the past is provided, the sandbox will be deleted immediately.
+                format: date-time
+                type: string
+              template:
+                description: |-
+                  Template describes the pods that will be created.
+                  Template is mutual exclusive with TemplateRef
+                x-kubernetes-preserve-unknown-fields: true
+              templateRef:
+                description: TemplateRef references a SandboxTemplate, which will
+                  be used to create the sandbox.
+                properties:
+                  apiVersion:
+                    description: |-
+                      name of the SandboxTemplate apiVersion
+                      Default to v1
+                    type: string
+                  kind:
+                    description: |-
+                      name of the SandboxTemplate kind
+                      Default to PodTemplate
+                    type: string
+                  name:
+                    description: name of the SandboxTemplate
+                    type: string
+                required:
+                - name
+                type: object
+              upgradePolicy:
+                description: UpgradePolicy defines the upgrade strategy for the sandbox.
+                properties:
+                  type:
+                    description: |-
+                      Type specifies the upgrade policy type.
+                      When empty (default), upgrading is disabled.
+                      Supported values: Recreate, CheckpointRestore.
+                    enum:
+                    - Recreate
+                    - CheckpointRestore
+                    type: string
+                type: object
+              volumeClaimTemplates:
+                description: VolumeClaimTemplates is a list of PVC templates to create
+                  for this Sandbox.
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: status defines the observed state of Sandbox
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the Sandbox resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
-                    type:
+                    lastTransitionTime:
                       description: |-
-                        Type specifies the upgrade policy type.
-                        When empty (default), upgrading is disabled.
-                        Supported values: Recreate.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
                       type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                volumeClaimTemplates:
-                  description: VolumeClaimTemplates is a list of PVC templates to create
-                    for this Sandbox.
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-            status:
-              description: status defines the observed state of Sandbox
-              properties:
-                conditions:
-                  description: |-
-                    conditions represent the current state of the Sandbox resource.
-                    Each condition has a unique type and reflects the status of a specific aspect of the resource.
-                    The status of each condition is one of True, False, or Unknown.
-                  items:
-                    description: Condition contains details for one aspect of the current
-                      state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              message:
+                description: message
+                type: string
+              nodeName:
+                description: NodeName indicates in which node this sandbox is scheduled.
+                type: string
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recent generation observed for this Sandbox. It corresponds to the
+                  Sandbox's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              phase:
+                description: Sandbox Phase
+                type: string
+              podInfo:
+                description: Pod Info
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations contains pod important annotations
                     type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                message:
-                  description: message
-                  type: string
-                nodeName:
-                  description: NodeName indicates in which node this sandbox is scheduled.
-                  type: string
-                observedGeneration:
+                    x-kubernetes-map-type: granular
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels contains pod important labels
+                    type: object
+                    x-kubernetes-map-type: granular
+                  nodeName:
+                    description: NodeName indicates in which node this pod is scheduled.
+                    type: string
+                  podIP:
+                    description: PodIP address allocated to the pod.
+                    type: string
+                  podUID:
+                    description: PodUID is pod uid.
+                    type: string
+                type: object
+              recycledCount:
+                description: RecycledCount records the number of times this sandbox
+                  has been recycled.
+                format: int32
+                type: integer
+              sandboxIp:
+                description: SandboxIp is the ip address allocated to the sandbox.
+                type: string
+              schedules:
+                description: |-
+                  Schedules contains upcoming scheduled pause/resume events.
+                  Only populated when Spec.AutoPausePolicy.Pause/Resume is configured.
+                items:
                   description: |-
-                    observedGeneration is the most recent generation observed for this Sandbox. It corresponds to the
-                    Sandbox's generation, which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-                phase:
-                  description: Sandbox Phase
-                  type: string
-                podInfo:
-                  description: Pod Info
+                    Schedule tracks the upcoming pause/resume timing for the auto-pause controller.
+                    Reason indicates which rule produced the current schedule, NextPauseTime is the
+                    next expected pause time, and NextResumeTime is the next expected resume time.
+                    Both times are cleared once the corresponding action is triggered.
                   properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations contains pod important annotations
-                      type: object
-                      x-kubernetes-map-type: granular
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels contains pod important labels
-                      type: object
-                      x-kubernetes-map-type: granular
-                    nodeName:
-                      description: NodeName indicates in which node this pod is scheduled.
+                    nextPauseTime:
+                      description: |-
+                        NextPauseTime is when the sandbox is expected to be paused, computed from
+                        the pause policy once the probed idle threshold is about to be reached.
+                        It is cleared after a pause is triggered.
+                      format: date-time
                       type: string
-                    podIP:
-                      description: PodIP address allocated to the pod.
+                    nextResumeTime:
+                      description: |-
+                        NextResumeTime is when the sandbox is expected to be resumed, computed from
+                        the resume policy's probed schedule time. It is cleared after a resume is triggered.
+                      format: date-time
                       type: string
-                    podUID:
-                      description: PodUID is pod uid.
+                    reason:
+                      description: |-
+                        Reason indicates which auto-pause rule triggered this schedule entry.
+                        Examples: "probedIdle" (pause triggered by WhenProbedIdleState),
+                        "probedSchedule" (resume triggered by WhenProbedScheduleTime).
                       type: string
                   type: object
-                sandboxIp:
-                  description: SandboxIp is the ip address allocated to the sandbox.
-                  type: string
-                updateRevision:
-                  description: UpdateRevision is the template-hash calculated from `spec.template`.
-                  type: string
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: { }
+                type: array
+              updateRevision:
+                description: UpdateRevision is the template-hash calculated from `spec.template`.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxsets.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxsets.yaml
@@ -12,257 +12,556 @@ spec:
     listKind: SandboxSetList
     plural: sandboxsets
     shortNames:
-      - sbs
+    - sbs
     singular: sandboxset
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.replicas
-          name: Replicas
-          type: integer
-        - jsonPath: .status.availableReplicas
-          name: Available
-          type: integer
-        - jsonPath: .status.updatedReplicas
-          name: UpdatedReplicas
-          type: integer
-        - jsonPath: .status.updatedAvailableReplicas
-          name: UpdatedAvailableReplicas
-          type: integer
-        - jsonPath: .status.updateRevision
-          name: UpdateRevision
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: SandboxSet is the Schema for the sandboxsets API, which is an
-            advanced workload for managing sandboxes.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec defines the desired state of SandboxSet
-              properties:
-                persistentContents:
-                  description: 'PersistentContents indicates resume pod with persistent
-                  content, Enum: ip, memory, filesystem'
-                  items:
-                    type: string
-                  type: array
-                  x-kubernetes-list-type: atomic
-                replicas:
-                  description: Replicas is the number of unused sandboxes, including
-                    available and creating ones.
-                  format: int32
-                  type: integer
-                runtimes:
-                  description: Runtimes - Runtime configuration for sandbox object
-                  items:
+  - additionalPrinterColumns:
+    - jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - jsonPath: .status.updatedReplicas
+      name: UpdatedReplicas
+      type: integer
+    - jsonPath: .status.updatedAvailableReplicas
+      name: UpdatedAvailableReplicas
+      type: integer
+    - jsonPath: .status.updateRevision
+      name: UpdateRevision
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SandboxSet is the Schema for the sandboxsets API, which is an
+          advanced workload for managing sandboxes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of SandboxSet
+            properties:
+              autoPausePolicy:
+                description: |-
+                  AutoPausePolicy defines the pause/resume decision rules for sandboxes
+                  created from this SandboxSet. Its rules reference probes by name, so it is
+                  normally set together with spec.probes. It is copied verbatim onto each
+                  created Sandbox and is part of the update revision hash, so changing it
+                  triggers a rolling update of already-created pool sandboxes.
+                properties:
+                  pause:
+                    description: Pause defines the pause policy for the sandbox.
                     properties:
-                      name:
-                        type: string
-                    required:
-                      - name
+                      whenProbedIdleState:
+                        description: |-
+                          WhenProbedIdleState pauses the sandbox when a probe's Condition message
+                          matches MessageRegex for at least ThresholdDuration.
+                        properties:
+                          messageRegex:
+                            description: |-
+                              MessageRegex is a regular expression matched against the probe's
+                              Condition message (stdout). When the message matches, the Agent is
+                              considered inactive. When it does not match, the Agent is considered
+                              active and the sandbox stays Running.
+                            type: string
+                          probe:
+                            description: |-
+                              Probe is the name of the probe to evaluate for pause decisions.
+                              Must match a probe name in Spec.Probes.
+                            type: string
+                          thresholdDuration:
+                            description: |-
+                              ThresholdDuration is the minimum time the probe's Condition message
+                              must continuously match MessageRegex before the sandbox is paused.
+                              Measured from the Condition's lastTransitionTime.
+
+                              It is required: pausing as soon as a single probe report matches would
+                              drop the smoothing this rule exists for, so there is no meaningful
+                              default and an unset value is a misconfiguration rather than
+                              "pause immediately".
+                            type: string
+                        required:
+                        - messageRegex
+                        - probe
+                        - thresholdDuration
+                        type: object
                     type: object
-                  type: array
-                  x-kubernetes-list-type: atomic
-                scaleStrategy:
+                  resume:
+                    description: Resume defines the resume policy for the sandbox.
+                    properties:
+                      whenProbedScheduleTime:
+                        description: |-
+                          WhenProbedScheduleTime resumes the sandbox before a scheduled task
+                          by parsing the probe's Condition message as a timestamp.
+                        properties:
+                          leadTime:
+                            default: 5m
+                            description: |-
+                              LeadTime is the duration before the parsed timestamp at which the
+                              sandbox should be resumed. For example, if the probe reports the
+                              next scheduled task at time T and LeadTime is 5m, the sandbox is
+                              resumed at T - 5m.
+                            type: string
+                          probe:
+                            description: |-
+                              Probe is the name of the probe to evaluate for resume decisions.
+                              Must match a probe name in Spec.Probes.
+                            type: string
+                          timeFormat:
+                            default: unix
+                            description: |-
+                              TimeFormat indicates the format of the probe's Condition message for
+                              parsing as a timestamp, and defaults to "unix":
+
+                                unix     - seconds since epoch, e.g. "1787040000"
+                                datetime - RFC3339 with offset, e.g. "2026-08-29T08:00:00+08:00"
+
+                              NextResumeTime is set to the parsed timestamp minus LeadTime.
+                            enum:
+                            - unix
+                            - datetime
+                            type: string
+                        required:
+                        - probe
+                        type: object
+                    type: object
+                type: object
+              pauseStrategy:
+                description: |-
+                  PauseStrategy configures how sandboxes created from this SandboxSet are
+                  paused when their spec.paused is true. It is copied verbatim onto each
+                  created Sandbox and is part of the update revision hash, so changing it
+                  triggers a rolling update of already-created pool sandboxes.
+                properties:
+                  hibernateStrategy:
+                    description: |-
+                      HibernateStrategy configures the storage medium for hibernate state.
+                      Only effective when Type is Hibernate.
+                    properties:
+                      type:
+                        description: Type selects the storage medium for hibernate
+                          state.
+                        type: string
+                    type: object
+                  type:
+                    description: Type selects the pause mechanism.
+                    enum:
+                    - Stop
+                    - Hibernate
+                    type: string
+                type: object
+              persistentContents:
+                description: 'PersistentContents indicates resume pod with persistent
+                  content, Enum: ip, memory, filesystem'
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              probes:
+                description: |-
+                  Probes defines the named probes that sandboxes created from this SandboxSet
+                  run while they are Running. It is copied verbatim onto each created Sandbox
+                  and is part of the update revision hash, so changing it triggers a rolling
+                  update of already-created pool sandboxes.
+                items:
                   description: |-
-                    ScaleStrategy indicates the ScaleStrategy that will be employed to
-                    create and delete Sandboxes in the SandboxSet.
+                    Probe defines a named probe that writes its result to a Pod Condition.
+                    Embeds corev1.Probe inline so that exec/periodSeconds/timeoutSeconds/etc.
+                    are directly accessible. Currently only exec probes are supported;
+                    other corev1.Probe fields (httpGet, tcpSocket, grpc) may be supported
+                    in the future as needed.
                   properties:
-                    maxUnavailable:
-                      anyOf:
-                        - type: integer
-                        - type: string
+                    containerName:
                       description: |-
-                        The maximum number of sandboxes that can be unavailable for scaled sandboxes.
-                        This field can control the changes rate of replicas for SandboxSet so as to minimize the impact for users' service.
-                        The scale will fail if the number of unavailable sandboxes were greater than this MaxUnavailable at scaling up.
-                        MaxUnavailable works only when scaling up.
-                      x-kubernetes-int-or-string: true
-                  type: object
-                template:
-                  description: |-
-                    Template describes the pods that will be created.
-                    Template is mutual exclusive with TemplateRef
-                  x-kubernetes-preserve-unknown-fields: true
-                templateRef:
-                  description: TemplateRef references a SandboxTemplate, which will
-                    be used to create the sandbox.
-                  properties:
-                    apiVersion:
-                      description: |-
-                        name of the SandboxTemplate apiVersion
-                        Default to v1
+                        ContainerName specifies which container to execute the probe in.
+                        If empty, defaults to the first container in the pod spec.
                       type: string
-                    kind:
+                    exec:
+                      description: Exec specifies a command to execute in the container.
+                      properties:
+                        command:
+                          description: |-
+                            Command is the command line to execute inside the container, the working directory for the
+                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                            a shell, you need to explicitly call out to that shell.
+                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    failureThreshold:
                       description: |-
-                        name of the SandboxTemplate kind
-                        Default to PodTemplate
-                      type: string
+                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                        Defaults to 3. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies a GRPC HealthCheckRequest.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          default: ""
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies an HTTP GET request to perform.
+                      properties:
+                        host:
+                          description: |-
+                            Host name to connect to, defaults to the pod IP. You probably want to set
+                            "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: |-
+                                  The header field name.
+                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Name or number of the port to access on the container.
+                            Number must be in the range 1 to 65535.
+                            Name must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host.
+                            Defaults to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: |-
+                        Number of seconds after the container has started before liveness probes are initiated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      format: int32
+                      type: integer
                     name:
-                      description: name of the SandboxTemplate
+                      description: |-
+                        Name is the unique identifier for this probe within the sandbox.
+                        Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      type: string
+                    periodSeconds:
+                      description: |-
+                        How often (in seconds) to perform the probe.
+                        Default to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: |-
+                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies a connection to a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Number or name of the port to access on the container.
+                            Number must be in the range 1 to 65535.
+                            Name must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: |-
+                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                        The grace period is the duration in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your process.
+                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                        value overrides the value provided by the pod spec.
+                        Value must be non-negative integer. The value zero indicates stop immediately via
+                        the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: |-
+                        Number of seconds after which the probe times out.
+                        Defaults to 1 second. Minimum value is 1.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              replicas:
+                description: Replicas is the number of unused sandboxes, including
+                  available and creating ones.
+                format: int32
+                type: integer
+              runtimes:
+                description: Runtimes - Runtime configuration for sandbox object
+                items:
+                  properties:
+                    name:
                       type: string
                   required:
-                    - name
+                  - name
                   type: object
-                updateStrategy:
-                  description: |-
-                    UpdateStrategy indicates the strategy that will be employed to
-                    update Sandboxes in the SandboxSet when the template changes.
+                type: array
+                x-kubernetes-list-type: atomic
+              scaleStrategy:
+                description: |-
+                  ScaleStrategy indicates the ScaleStrategy that will be employed to
+                  create and delete Sandboxes in the SandboxSet.
+                properties:
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxUnavailable caps the number of unavailable sandboxes during scale-up.
+                      It can be an absolute number (ex: 5) or a percentage of desired pods
+                      (ex: 10%); percentages are rounded up. Every non-Available sandbox counts
+                      against the physical scale-up budget. If unset or invalid, the controller
+                      uses the base (equivalent to 100%, i.e. no cap).
+
+                      The ScalingLimited condition uses the same resolved value as a separate
+                      startup budget and becomes True with reason StartupBudgetExhausted when
+                      definitive startup failures plus pending-timeout sandboxes exhaust it.
+                      Scale-down is unaffected.
+                      MaxUnavailable works only for scale-up.
+                    x-kubernetes-int-or-string: true
+                type: object
+              template:
+                description: |-
+                  Template describes the pods that will be created.
+                  Template is mutual exclusive with TemplateRef
+                x-kubernetes-preserve-unknown-fields: true
+              templateRef:
+                description: TemplateRef references a SandboxTemplate, which will
+                  be used to create the sandbox.
+                properties:
+                  apiVersion:
+                    description: |-
+                      name of the SandboxTemplate apiVersion
+                      Default to v1
+                    type: string
+                  kind:
+                    description: |-
+                      name of the SandboxTemplate kind
+                      Default to PodTemplate
+                    type: string
+                  name:
+                    description: name of the SandboxTemplate
+                    type: string
+                required:
+                - name
+                type: object
+              updateStrategy:
+                description: |-
+                  UpdateStrategy indicates the strategy that will be employed to
+                  update Sandboxes in the SandboxSet when the template changes.
+                properties:
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxUnavailable is the maximum number or percentage of pods that can be unavailable during the update.
+                      MaxUnavailable can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                      Absolute number is calculated from percentage by rounding down.
+                      Default is 20%.
+                    x-kubernetes-int-or-string: true
+                type: object
+              volumeClaimTemplates:
+                description: VolumeClaimTemplates is a list of PVC templates to create
+                  for this Sandbox.
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - replicas
+            type: object
+          status:
+            description: status defines the observed state of SandboxSet
+            properties:
+              availableReplicas:
+                description: AvailableReplicas is the number of available sandboxes,
+                  which are ready to be claimed.
+                format: int32
+                type: integer
+              conditions:
+                description: |-
+                  conditions represent the current state of the SandboxSet resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
-                    maxUnavailable:
-                      anyOf:
-                        - type: integer
-                        - type: string
+                    lastTransitionTime:
                       description: |-
-                        MaxUnavailable is the maximum number or percentage of pods that can be unavailable during the update.
-                        MaxUnavailable can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                        Absolute number is calculated from percentage by rounding down.
-                        Default is 20%.
-                      x-kubernetes-int-or-string: true
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                volumeClaimTemplates:
-                  description: VolumeClaimTemplates is a list of PVC templates to create
-                    for this Sandbox.
-                  x-kubernetes-preserve-unknown-fields: true
-              required:
-                - replicas
-              type: object
-            status:
-              description: status defines the observed state of SandboxSet
-              properties:
-                availableReplicas:
-                  description: AvailableReplicas is the number of available sandboxes,
-                    which are ready to be claimed.
-                  format: int32
-                  type: integer
-                conditions:
-                  description: |-
-                    conditions represent the current state of the SandboxSet resource.
-                    Each condition has a unique type and reflects the status of a specific aspect of the resource.
-                    The status of each condition is one of True, False, or Unknown.
-                  items:
-                    description: Condition contains details for one aspect of the current
-                      state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                observedGeneration:
-                  description: |-
-                    observedGeneration is the most recent generation observed for this SandboxSet. It corresponds to the
-                    SandboxSet's generation, which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-                replicas:
-                  description: Replicas is the total number of creating, available,
-                    running and paused sandboxes.
-                  format: int32
-                  type: integer
-                selector:
-                  description: |-
-                    Selector is a label query over pods that should match the replica count.
-                    This is same as the label selector but in the string format to avoid
-                    duplication for CRDs that do not support structural schemas.
-                  type: string
-                updateRevision:
-                  description: |-
-                    UpdateRevision is the hash label of the ControllerRevision created from `spec.template`.
-                    It represents the latest desired template version.
-                  type: string
-                updatedAvailableReplicas:
-                  description: UpdatedAvailableReplicas is the number of updated sandboxes
-                    that are available.
-                  format: int32
-                  type: integer
-                updatedReplicas:
-                  description: UpdatedReplicas is the number of sandboxes that have
-                    been updated to the UpdateRevision.
-                  format: int32
-                  type: integer
-              required:
-                - availableReplicas
-                - replicas
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        scale:
-          labelSelectorPath: .status.selector
-          specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.replicas
-        status: { }
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentRevision:
+                description: |-
+                  CurrentRevision is the SandboxTemplate name corresponding to the currently
+                  materialised revision, or spec.templateRef.Name when templateRef is used.
+                type: string
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recent generation observed for this SandboxSet. It corresponds to the
+                  SandboxSet's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              replicas:
+                description: Replicas is the total number of creating, available,
+                  running and paused sandboxes.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Selector is a label query over pods that should match the replica count.
+                  This is same as the label selector but in the string format to avoid
+                  duplication for CRDs that do not support structural schemas.
+                type: string
+              updateRevision:
+                description: |-
+                  UpdateRevision is the FNV-32 hash computed from spec.template,
+                  spec.persistentContents, spec.runtimes, spec.pauseStrategy,
+                  spec.probes, and spec.autoPausePolicy.
+                  It represents the latest desired template version.
+                type: string
+              updatedAvailableReplicas:
+                description: UpdatedAvailableReplicas is the number of updated sandboxes
+                  that are available.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: UpdatedReplicas is the number of sandboxes that have
+                  been updated to the UpdateRevision.
+                format: int32
+                type: integer
+            required:
+            - availableReplicas
+            - replicas
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxtemplates.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxtemplates.yaml
@@ -12,66 +12,350 @@ spec:
     listKind: SandboxTemplateList
     plural: sandboxtemplates
     shortNames:
-      - sbt
+    - sbt
     singular: sandboxtemplate
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: SandboxSet is the Schema for the sandboxsets API, which is an
-            advanced workload for managing sandboxes.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec defines the desired state of SandboxSet
-              properties:
-                persistentContents:
-                  description: 'PersistentContents indicates resume pod with persistent
-                  content, Enum: ip, memory, filesystem'
-                  items:
-                    type: string
-                  type: array
-                  x-kubernetes-list-type: atomic
-                runtimes:
-                  description: Runtimes - Runtime configuration for sandbox object
-                  items:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SandboxSet is the Schema for the sandboxsets API, which is an
+          advanced workload for managing sandboxes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of SandboxSet
+            properties:
+              autoPausePolicy:
+                description: |-
+                  AutoPausePolicy defines the pause/resume decision rules for sandboxes
+                  created from this template. It is only informational when a SandboxSet uses
+                  spec.templateRef: SandboxSetSpec.AutoPausePolicy always takes precedence and
+                  is what actually reaches created Sandboxes.
+                properties:
+                  pause:
+                    description: Pause defines the pause policy for the sandbox.
                     properties:
-                      name:
-                        type: string
-                    required:
-                      - name
+                      whenProbedIdleState:
+                        description: |-
+                          WhenProbedIdleState pauses the sandbox when a probe's Condition message
+                          matches MessageRegex for at least ThresholdDuration.
+                        properties:
+                          messageRegex:
+                            description: |-
+                              MessageRegex is a regular expression matched against the probe's
+                              Condition message (stdout). When the message matches, the Agent is
+                              considered inactive. When it does not match, the Agent is considered
+                              active and the sandbox stays Running.
+                            type: string
+                          probe:
+                            description: |-
+                              Probe is the name of the probe to evaluate for pause decisions.
+                              Must match a probe name in Spec.Probes.
+                            type: string
+                          thresholdDuration:
+                            description: |-
+                              ThresholdDuration is the minimum time the probe's Condition message
+                              must continuously match MessageRegex before the sandbox is paused.
+                              Measured from the Condition's lastTransitionTime.
+
+                              It is required: pausing as soon as a single probe report matches would
+                              drop the smoothing this rule exists for, so there is no meaningful
+                              default and an unset value is a misconfiguration rather than
+                              "pause immediately".
+                            type: string
+                        required:
+                        - messageRegex
+                        - probe
+                        - thresholdDuration
+                        type: object
                     type: object
-                  type: array
-                  x-kubernetes-list-type: atomic
-                template:
+                  resume:
+                    description: Resume defines the resume policy for the sandbox.
+                    properties:
+                      whenProbedScheduleTime:
+                        description: |-
+                          WhenProbedScheduleTime resumes the sandbox before a scheduled task
+                          by parsing the probe's Condition message as a timestamp.
+                        properties:
+                          leadTime:
+                            default: 5m
+                            description: |-
+                              LeadTime is the duration before the parsed timestamp at which the
+                              sandbox should be resumed. For example, if the probe reports the
+                              next scheduled task at time T and LeadTime is 5m, the sandbox is
+                              resumed at T - 5m.
+                            type: string
+                          probe:
+                            description: |-
+                              Probe is the name of the probe to evaluate for resume decisions.
+                              Must match a probe name in Spec.Probes.
+                            type: string
+                          timeFormat:
+                            default: unix
+                            description: |-
+                              TimeFormat indicates the format of the probe's Condition message for
+                              parsing as a timestamp, and defaults to "unix":
+
+                                unix     - seconds since epoch, e.g. "1787040000"
+                                datetime - RFC3339 with offset, e.g. "2026-08-29T08:00:00+08:00"
+
+                              NextResumeTime is set to the parsed timestamp minus LeadTime.
+                            enum:
+                            - unix
+                            - datetime
+                            type: string
+                        required:
+                        - probe
+                        type: object
+                    type: object
+                type: object
+              pauseStrategy:
+                description: |-
+                  PauseStrategy configures how sandboxes created from this template are
+                  paused when their spec.paused is true. It is only informational when a
+                  SandboxSet uses spec.templateRef: SandboxSetSpec.PauseStrategy always
+                  takes precedence and is what actually reaches created Sandboxes.
+                properties:
+                  hibernateStrategy:
+                    description: |-
+                      HibernateStrategy configures the storage medium for hibernate state.
+                      Only effective when Type is Hibernate.
+                    properties:
+                      type:
+                        description: Type selects the storage medium for hibernate
+                          state.
+                        type: string
+                    type: object
+                  type:
+                    description: Type selects the pause mechanism.
+                    enum:
+                    - Stop
+                    - Hibernate
+                    type: string
+                type: object
+              persistentContents:
+                description: 'PersistentContents indicates resume pod with persistent
+                  content, Enum: ip, memory, filesystem'
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              probes:
+                description: |-
+                  Probes defines the named probes that sandboxes created from this template
+                  run while they are Running. It is only informational when a SandboxSet uses
+                  spec.templateRef: SandboxSetSpec.Probes always takes precedence and is what
+                  actually reaches created Sandboxes.
+                items:
                   description: |-
-                    Template describes the pods that will be created.
-                    Template is mutual exclusive with TemplateRef
-                  x-kubernetes-preserve-unknown-fields: true
-                volumeClaimTemplates:
-                  description: VolumeClaimTemplates is a list of PVC templates to create
-                    for this Sandbox.
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
+                    Probe defines a named probe that writes its result to a Pod Condition.
+                    Embeds corev1.Probe inline so that exec/periodSeconds/timeoutSeconds/etc.
+                    are directly accessible. Currently only exec probes are supported;
+                    other corev1.Probe fields (httpGet, tcpSocket, grpc) may be supported
+                    in the future as needed.
+                  properties:
+                    containerName:
+                      description: |-
+                        ContainerName specifies which container to execute the probe in.
+                        If empty, defaults to the first container in the pod spec.
+                      type: string
+                    exec:
+                      description: Exec specifies a command to execute in the container.
+                      properties:
+                        command:
+                          description: |-
+                            Command is the command line to execute inside the container, the working directory for the
+                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                            a shell, you need to explicitly call out to that shell.
+                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    failureThreshold:
+                      description: |-
+                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                        Defaults to 3. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies a GRPC HealthCheckRequest.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          default: ""
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies an HTTP GET request to perform.
+                      properties:
+                        host:
+                          description: |-
+                            Host name to connect to, defaults to the pod IP. You probably want to set
+                            "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: |-
+                                  The header field name.
+                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Name or number of the port to access on the container.
+                            Number must be in the range 1 to 65535.
+                            Name must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host.
+                            Defaults to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: |-
+                        Number of seconds after the container has started before liveness probes are initiated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      format: int32
+                      type: integer
+                    name:
+                      description: |-
+                        Name is the unique identifier for this probe within the sandbox.
+                        Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      type: string
+                    periodSeconds:
+                      description: |-
+                        How often (in seconds) to perform the probe.
+                        Default to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: |-
+                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies a connection to a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Number or name of the port to access on the container.
+                            Number must be in the range 1 to 65535.
+                            Name must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: |-
+                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                        The grace period is the duration in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your process.
+                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                        value overrides the value provided by the pod spec.
+                        Value must be non-negative integer. The value zero indicates stop immediately via
+                        the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: |-
+                        Number of seconds after which the probe times out.
+                        Defaults to 1 second. Minimum value is 1.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              runtimes:
+                description: Runtimes - Runtime configuration for sandbox object
+                items:
+                  properties:
+                    name:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              template:
+                description: |-
+                  Template describes the pods that will be created.
+                  Template is mutual exclusive with TemplateRef
+                x-kubernetes-preserve-unknown-fields: true
+              volumeClaimTemplates:
+                description: VolumeClaimTemplates is a list of PVC templates to create
+                  for this Sandbox.
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxupdateops.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxupdateops.yaml
@@ -12,288 +12,319 @@ spec:
     listKind: SandboxUpdateOpsList
     plural: sandboxupdateops
     shortNames:
-      - suo
+    - suo
     singular: sandboxupdateops
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.phase
-          name: Phase
-          type: string
-        - jsonPath: .status.replicas
-          name: Total
-          type: integer
-        - jsonPath: .status.updatedReplicas
-          name: Updated
-          type: integer
-        - jsonPath: .status.updatingReplicas
-          name: Updating
-          type: integer
-        - jsonPath: .status.failedReplicas
-          name: Failed
-          type: integer
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: SandboxUpdateOps is the Schema for batch sandbox update operations.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec defines the desired update operation.
-              properties:
-                lifecycle:
-                  description: Lifecycle defines pre/post upgrade hooks to set on each
-                    sandbox during upgrade.
-                  properties:
-                    postUpgrade:
-                      description: |-
-                        PostUpgrade is the action executed after the upgrade.
-                        It is typically used to restore workspace data.
-                      properties:
-                        exec:
-                          description: |-
-                            Exec specifies the command to execute inside the sandbox via envd.
-                            The first element is the command, the rest are args.
-                            For shell scripts, use: ["/bin/bash", "-c", "your-script"]
-                          properties:
-                            command:
-                              description: |-
-                                Command is the command line to execute inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                a shell, you need to explicitly call out to that shell.
-                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          type: object
-                        timeoutSeconds:
-                          default: 60
-                          description: TimeoutSeconds is the timeout for the action
-                            execution in seconds.
-                          format: int32
-                          type: integer
-                      type: object
-                    preUpgrade:
-                      description: |-
-                        PreUpgrade is the action executed before the upgrade.
-                        It is typically used to backup workspace data.
-                      properties:
-                        exec:
-                          description: |-
-                            Exec specifies the command to execute inside the sandbox via envd.
-                            The first element is the command, the rest are args.
-                            For shell scripts, use: ["/bin/bash", "-c", "your-script"]
-                          properties:
-                            command:
-                              description: |-
-                                Command is the command line to execute inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                a shell, you need to explicitly call out to that shell.
-                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          type: object
-                        timeoutSeconds:
-                          default: 60
-                          description: TimeoutSeconds is the timeout for the action
-                            execution in seconds.
-                          format: int32
-                          type: integer
-                      type: object
-                  type: object
-                patch:
-                  description: |-
-                    Patch defines the changes to apply to each selected sandbox's template.
-                    The patch is applied as a Strategic Merge Patch on the sandbox's PodTemplateSpec.
-                  x-kubernetes-preserve-unknown-fields: true
-                paused:
-                  description: Paused indicates whether the update operation is paused.
-                  type: boolean
-                selector:
-                  description: Selector selects the target sandboxes to update by label.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.replicas
+      name: Total
+      type: integer
+    - jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - jsonPath: .status.updatingReplicas
+      name: Updating
+      type: integer
+    - jsonPath: .status.failedReplicas
+      name: Failed
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SandboxUpdateOps is the Schema for batch sandbox update operations.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired update operation.
+            properties:
+              lifecycle:
+                description: Lifecycle defines pre/post upgrade hooks to set on each
+                  sandbox during upgrade.
+                properties:
+                  postUpgrade:
+                    description: |-
+                      PostUpgrade is the action executed after the upgrade.
+                      It is typically used to restore workspace data.
+                    properties:
+                      exec:
                         description: |-
-                          A label selector requirement is a selector that contains values, a key, and an operator that
-                          relates the key and values.
+                          Exec specifies the command to execute inside the sandbox via envd.
+                          The first element is the command, the rest are args.
+                          For shell scripts, use: ["/bin/bash", "-c", "your-script"]
                         properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
+                          command:
                             description: |-
-                              operator represents a key's relationship to a set of values.
-                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: |-
-                              values is an array of string values. If the operator is In or NotIn,
-                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                              the values array must be empty. This array is replaced during a strategic
-                              merge patch.
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
-                        required:
-                          - key
-                          - operator
                         type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                  type: object
-                  x-kubernetes-map-type: atomic
-                updateStrategy:
-                  description: UpdateStrategy defines the strategy for the batch update.
-                  properties:
-                    maxUnavailable:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: |-
-                        MaxUnavailable is the maximum number of sandboxes that can be upgrading at the same time.
-                        Value can be an absolute number (e.g., 5) or a percentage of total sandboxes (e.g., 10%).
-                      x-kubernetes-int-or-string: true
-                  type: object
-              required:
-                - selector
-              type: object
-            status:
-              description: Status defines the observed state.
-              properties:
-                conditions:
-                  description: Conditions represents the latest available observations.
-                  items:
-                    description: Condition contains details for one aspect of the current
-                      state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
+                      timeoutSeconds:
+                        default: 60
+                        description: TimeoutSeconds is the timeout for the action
+                          execution in seconds.
+                        format: int32
                         type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
                     type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                failedReplicas:
-                  description: FailedReplicas is the number of sandboxes that failed
-                    to update.
-                  format: int32
-                  type: integer
-                observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed.
-                  format: int64
-                  type: integer
-                phase:
-                  description: Phase is the current phase of the update operation.
-                  type: string
-                replicas:
-                  description: Replicas is the total number of sandboxes selected for
-                    update.
-                  format: int32
-                  type: integer
-                updatedReplicas:
-                  description: UpdatedReplicas is the number of sandboxes that have
-                    been successfully updated.
-                  format: int32
-                  type: integer
-                updatingReplicas:
-                  description: UpdatingReplicas is the number of sandboxes currently
-                    being updated.
-                  format: int32
-                  type: integer
-              required:
-                - failedReplicas
-                - replicas
-                - updatedReplicas
-                - updatingReplicas
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: { }
+                  preUpgrade:
+                    description: |-
+                      PreUpgrade is the action executed before the upgrade.
+                      It is typically used to backup workspace data.
+                    properties:
+                      exec:
+                        description: |-
+                          Exec specifies the command to execute inside the sandbox via envd.
+                          The first element is the command, the rest are args.
+                          For shell scripts, use: ["/bin/bash", "-c", "your-script"]
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      timeoutSeconds:
+                        default: 60
+                        description: TimeoutSeconds is the timeout for the action
+                          execution in seconds.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+              patch:
+                description: |-
+                  Patch defines the changes to apply to each selected sandbox's template.
+                  The patch is applied as a Strategic Merge Patch on the sandbox's PodTemplateSpec.
+                x-kubernetes-preserve-unknown-fields: true
+              paused:
+                description: Paused indicates whether the update operation is paused.
+                type: boolean
+              selector:
+                description: Selector selects the target sandboxes to update by label.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              stateFilter:
+                description: |-
+                  StateFilter specifies which sandbox states are eligible as upgrade
+                  candidates. When empty, defaults to [Running].
+                  Upgrading sandboxes are always tracked regardless of this field, as they
+                  represent in-progress upgrades owned by this ops.
+                properties:
+                  states:
+                    description: |-
+                      States specifies which sandbox phases are eligible as upgrade candidates.
+                      When empty, defaults to [Running].
+                      Supported values: Running, Paused.
+                    items:
+                      description: SandboxPhase is a label for the condition of a
+                        pod at the current time.
+                      enum:
+                      - Running
+                      - Paused
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+              updateStrategy:
+                description: UpdateStrategy defines the strategy for the batch update.
+                properties:
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxUnavailable is the maximum number of sandboxes that can be upgrading at the same time.
+                      Value can be an absolute number (e.g., 5) or a percentage of total sandboxes (e.g., 10%).
+                    x-kubernetes-int-or-string: true
+                  type:
+                    description: |-
+                      Type specifies the update strategy type.
+                      When empty, defaults to Recreate.
+                      Supported values: Recreate, CheckpointRestore.
+                    enum:
+                    - Recreate
+                    - CheckpointRestore
+                    type: string
+                type: object
+            required:
+            - selector
+            type: object
+          status:
+            description: Status defines the observed state.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              failedReplicas:
+                description: FailedReplicas is the number of sandboxes that failed
+                  to update.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed.
+                format: int64
+                type: integer
+              phase:
+                description: Phase is the current phase of the update operation.
+                type: string
+              replicas:
+                description: Replicas is the total number of sandboxes selected for
+                  update.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: UpdatedReplicas is the number of sandboxes that have
+                  been successfully updated.
+                format: int32
+                type: integer
+              updatingReplicas:
+                description: UpdatingReplicas is the number of sandboxes currently
+                  being updated.
+                format: int32
+                type: integer
+            required:
+            - failedReplicas
+            - replicas
+            - updatedReplicas
+            - updatingReplicas
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/versions/kruise-agents-sandbox-controller/next/templates/rbac.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/rbac.yaml
@@ -111,6 +111,13 @@ rules:
       - patch
       - update
   - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations
@@ -127,14 +134,7 @@ rules:
       - checkpoints
       - sandboxtemplates
     verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - agents.kruise.io
-    resources:
-      - sandboxclaims
-    verbs:
+      - create
       - delete
       - get
       - list
@@ -143,17 +143,8 @@ rules:
   - apiGroups:
       - agents.kruise.io
     resources:
-      - sandboxclaims/status
-      - sandboxes/status
-      - sandboxsets/status
-      - sandboxupdateops/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - agents.kruise.io
-    resources:
+      - commits
+      - poolautoscalers
       - sandboxes
       - sandboxsets
       - sandboxupdateops
@@ -168,10 +159,54 @@ rules:
   - apiGroups:
       - agents.kruise.io
     resources:
+      - commits/finalizers
       - sandboxes/finalizers
       - sandboxsets/finalizers
     verbs:
       - update
+  - apiGroups:
+      - agents.kruise.io
+    resources:
+      - commits/status
+      - poolautoscalers/status
+      - sandboxclaims/status
+      - sandboxes/status
+      - sandboxsets/status
+      - sandboxupdateops/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - agents.kruise.io
+    resources:
+      - sandboxclaims
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - agents.kruise.io
+    resources:
+      - trafficpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/versions/kruise-agents-sandbox-controller/next/templates/webhook.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/webhook.yaml
@@ -162,3 +162,24 @@ webhooks:
         resources:
           - sandboxupdateops
     sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: sandbox-controller-manager-webhook-service
+        namespace: {{ include "sandbox-controller.namespace" . }}
+        path: /validate-poolautoscaler
+    failurePolicy: Fail
+    name: v-pa.kb.io
+    rules:
+      - apiGroups:
+          - agents.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - poolautoscalers
+    sideEffects: None

--- a/versions/kruise-agents-sandbox-manager/next/templates/rbac.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/rbac.yaml
@@ -12,17 +12,32 @@ rules:
     resources: [ "pods/status" ]
     verbs: [ "get", "update", "patch" ]
   - apiGroups: [ "" ]
+    resources: [ "namespaces" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
     resources: [ "events" ]
     verbs: [ "create", "patch" ]
   - apiGroups: [ "agents.kruise.io" ]
-    resources: [ "sandboxes", "sandboxsets", "checkpoints", "sandboxtemplates" ]
+    resources: [ "sandboxes", "sandboxsets", "checkpoints", "sandboxtemplates", "trafficpolicies" ]
     verbs: [ "get", "list", "watch", "update", "patch", "delete", "create" ]
   - apiGroups: [ "agents.kruise.io" ]
     resources: [ "sandboxes/status", "sandboxsets/status" ]
     verbs: [ "get", "update", "patch" ]
   - apiGroups: [ "" ]
-    resources: [ "persistentvolumes", "configmaps" ]
+    resources: [ "persistentvolumes" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "secrets", "configmaps" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch", "create", "delete" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "storageclasses" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources: [ "leases" ]
+    verbs: [ "get", "list", "watch", "create", "update" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -34,6 +49,8 @@ metadata:
 rules:
   - apiGroups: [ "" ]
     resources: [ "secrets" ]
+    resourceNames:
+      - e2b-key-store
     verbs: [ "get", "list", "watch", "update", "patch" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -76,7 +93,7 @@ metadata:
 rules:
   - apiGroups: ["agents.kruise.io"]
     resources: ["sandboxes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["agents.kruise.io"]
     resources: ["sandboxes/status"]
     verbs: ["get"]


### PR DESCRIPTION
## Summary

Sync `versions/kruise-agents-sandbox-{controller,manager}/next/` with the OpenKruise Agents source at commit `6c8feb4e0fcdb0d15da1c76dd8faa699626880d2`.

## Changes

### Controller chart

- **CRDs**: synced all mapped CRDs from `config/crd/bases`:
  - `agents.kruise.io_checkpoints.yaml`
  - `agents.kruise.io_commits.yaml` (new)
  - `agents.kruise.io_poolautoscalers.yaml` (new)
  - `agents.kruise.io_sandboxclaims.yaml`
  - `agents.kruise.io_sandboxes.yaml`
  - `agents.kruise.io_sandboxsets.yaml`
  - `agents.kruise.io_sandboxtemplates.yaml`
  - `agents.kruise.io_sandboxupdateops.yaml`
- **Webhook**: added `v-pa.kb.io` validating webhook for `poolautoscalers`.
- **RBAC**: updated controller ClusterRole with:
  - `commits` and `poolautoscalers` resources
  - `commits/finalizers`, `commits/status`, `poolautoscalers/status`
  - `trafficpolicies`, `batch/jobs`
  - cluster-scoped `secrets` read, `namespaces`, `persistentvolumeclaims`, `storageclasses`, `leases`

### Manager chart

- **CRD**: `trafficpolicy-crd.yaml` already in sync.
- **RBAC**: updated manager ClusterRole with `namespaces`, `trafficpolicies`, `persistentvolumeclaims`, `storageclasses`, `leases`; restricted secret Role to `resourceNames: [e2b-key-store]`; updated gateway ClusterRole with `sandboxes` update/patch verbs.

## Drift checker output

Initial run:
```
DRIFT crd controller .../agents.kruise.io_checkpoints.yaml content
DRIFT crd controller .../agents.kruise.io_commits.yaml missing
DRIFT crd controller .../agents.kruise.io_sandboxes.yaml content
DRIFT crd controller .../agents.kruise.io_sandboxsets.yaml content
DRIFT crd controller .../agents.kruise.io_sandboxclaims.yaml content
DRIFT crd controller .../agents.kruise.io_sandboxtemplates.yaml content
DRIFT crd controller .../agents.kruise.io_sandboxupdateops.yaml content
OK crd manager .../trafficpolicy-crd.yaml
DRIFT crd controller .../agents.kruise.io_poolautoscalers.yaml missing
```

Final run:
```
OK crd controller ... (all OK)
OK crd manager .../trafficpolicy-crd.yaml
```

## CRD upgrade impact

This PR adds two new CRDs (`commits` and `poolautoscalers`) and updates several existing CRDs. Helm will apply the updated CRDs on upgrade, but the new CRDs must be installed manually if the cluster does not already have them.