### PR TITLE
feat(kruise-agents): sync Agentio 0.1.1

### DIFF
--- a/versions/kruise-agents-sandbox-manager/next/templates/agentio/_agentio-config.tpl
+++ b/versions/kruise-agents-sandbox-manager/next/templates/agentio/_agentio-config.tpl
@@ -22,4 +22,23 @@ sandboxExtProc:
 egressPolicies:
 {{ toYaml .Values.agentio.egressPolicies }}
 {{- end }}
+{{- $defaultServiceEntries := .Values.agentio.egressGateway.serviceEntries | default list }}
+{{- $configuredGateways := list }}
+{{- range $gateway := .Values.agentio.egressGateway.gateways }}
+{{- $serviceEntries := $defaultServiceEntries }}
+{{- if hasKey $gateway "serviceEntries" }}
+{{- $serviceEntries = $gateway.serviceEntries }}
+{{- end }}
+{{- if $serviceEntries }}
+{{- $configuredGateways = append $configuredGateways (dict
+  "name" $gateway.name
+  "namespace" (include "agentio.namespace" $)
+  "serviceEntries" $serviceEntries
+) }}
+{{- end }}
+{{- end }}
+{{- if $configuredGateways }}
+egressGateways:
+{{ toYaml $configuredGateways }}
+{{- end }}
 {{- end }}

--- a/versions/kruise-agents-sandbox-manager/next/values.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/values.yaml
@@ -344,10 +344,23 @@ agentio:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    # -- Default static service entries for all gateways. A gateway may replace
+    # the complete list with gateways[].serviceEntries, including an empty list.
+    serviceEntries: []
     # -- One entry per egress gateway. Minimal form: [{ name: my-egress }].
     # Each entry may override: labels, replicas, resources, autoscaling,
     # nodeSelector, tolerations, affinity, pdbMinAvailable,
-    # terminationGracePeriodSeconds, statsFlushInterval, statsEvictionInterval.
+    # terminationGracePeriodSeconds, statsFlushInterval, statsEvictionInterval,
+    # serviceEntries.
+    # Example:
+    # gateways:
+    #   - name: egress-gateway
+    #     serviceEntries:
+    #       - hosts:
+    #           - bff-cn-beijing.data.aliyun-inc.com
+    #         endpoints:
+    #           - address: 10.10.20.30
+    #           - address: 10.10.20.31
     gateways: []
   # -- Raw overrides merged on top of the built-in agentio-config ConfigMap body.
   # Use this to set fields the chart does not model explicitly (e.g. clusterSettings)


### PR DESCRIPTION
Embeds the released Agentio 0.1.1 chart into the sandbox-manager next chart and syncs its Kruise Agents traffic-proxy injection configuration into the sandbox-controller next chart. Source release: https://github.com/openkruise/agentio/releases/tag/0.1.1.