### PR TITLE
sync(agents): align next charts with agents config at 8f835ef60

### DIFF
--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_poolautoscalers.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_poolautoscalers.yaml
@@ -163,7 +163,11 @@ spec:
                   - schedule
                   - targetReplicas
                   type: object
+                maxItems: 20
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               maxReplicas:
                 description: |-
                   MaxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
@@ -232,6 +236,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               conditions:
                 description: Conditions is the set of conditions required for this
                   autoscaler to scale its target.
@@ -333,6 +340,8 @@ spec:
             - currentReplicas
             - desiredReplicas
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxes.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxes.yaml
@@ -65,8 +65,12 @@ spec:
             properties:
               autoPausePolicy:
                 description: |-
-                  AutoPausePolicy defines pause/resume decision rules based on probe
-                  Conditions. Probes are defined in Spec.Probes.
+                  AutoPausePolicy defines when the sandbox controller pauses or resumes
+                  the sandbox. Probe-driven rules reference probes declared in
+                  Spec.Probes and read their results (mirrored from
+                  Pod.Status.Conditions to SandboxStatus.Conditions); the
+                  OnIngressTraffic resume rule is event-driven and does not require a
+                  probe.
                 properties:
                   pause:
                     description: Pause defines the pause policy for the sandbox.
@@ -82,6 +86,7 @@ spec:
                               Condition message (stdout). When the message matches, the Agent is
                               considered inactive. When it does not match, the Agent is considered
                               active and the sandbox stays Running.
+                            maxLength: 512
                             type: string
                           probe:
                             description: |-
@@ -108,6 +113,30 @@ spec:
                   resume:
                     description: Resume defines the resume policy for the sandbox.
                     properties:
+                      onIngressTraffic:
+                        description: |-
+                          OnIngressTraffic resumes the sandbox when the sandbox-gateway receives
+                          inbound traffic addressed to it while it is paused. Unlike the probed
+                          rules this one is event-driven: it needs no probe, it produces no
+                          Status.Schedules entry, and it is executed by the sandbox-gateway rather
+                          than by the sandbox controller.
+                        properties:
+                          pauseTimeout:
+                            description: |-
+                              PauseTimeout is the auto-pause timeout re-armed by a traffic wake: the
+                              gateway writes Spec.PauseTime = now + PauseTimeout atomically with
+                              Spec.Paused = false, so the woken sandbox has running time before its
+                              next auto-pause. It applies only to auto-pause sandboxes (those that
+                              already carry Spec.PauseTime); never-timeout and shutdown-only
+                              sandboxes keep their timeout mode unchanged.
+                              When absent or non-positive, a traffic wake does not re-arm auto-pause:
+                              the woken sandbox keeps running until it is paused or deleted again.
+                              A positive value is subject to the resume timeout floor
+                              (timeout.DefaultMinResumeTimeoutSeconds, currently 300s): values below
+                              the floor are raised to it so the fresh PauseTime cannot expire while
+                              the sandbox is still resuming.
+                            type: string
+                        type: object
                       whenProbedScheduleTime:
                         description: |-
                           WhenProbedScheduleTime resumes the sandbox before a scheduled task
@@ -369,6 +398,8 @@ spec:
                       description: |-
                         Name is the unique identifier for this probe within the sandbox.
                         Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      maxLength: 299
+                      pattern: ^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
                       type: string
                     periodSeconds:
                       description: |-
@@ -425,7 +456,11 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 16
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               runtimes:
                 description: Runtimes - Runtime configuration for sandbox object
                 items:
@@ -630,8 +665,13 @@ spec:
                         Examples: "probedIdle" (pause triggered by WhenProbedIdleState),
                         "probedSchedule" (resume triggered by WhenProbedScheduleTime).
                       type: string
+                  required:
+                  - reason
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - reason
+                x-kubernetes-list-type: map
               updateRevision:
                 description: UpdateRevision is the template-hash calculated from `spec.template`.
                 type: string

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxsets.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxsets.yaml
@@ -64,10 +64,12 @@ spec:
               autoPausePolicy:
                 description: |-
                   AutoPausePolicy defines the pause/resume decision rules for sandboxes
-                  created from this SandboxSet. Its rules reference probes by name, so it is
-                  normally set together with spec.probes. It is copied verbatim onto each
-                  created Sandbox and is part of the update revision hash, so changing it
-                  triggers a rolling update of already-created pool sandboxes.
+                  created from this SandboxSet. Probe-driven rules reference probes by
+                  name (so they are normally set together with spec.probes); the
+                  OnIngressTraffic resume rule is event-driven and does not require a
+                  probe. The policy is copied verbatim onto each created Sandbox and is
+                  part of the update revision hash, so changing it triggers a rolling
+                  update of already-created pool sandboxes.
                 properties:
                   pause:
                     description: Pause defines the pause policy for the sandbox.
@@ -83,6 +85,7 @@ spec:
                               Condition message (stdout). When the message matches, the Agent is
                               considered inactive. When it does not match, the Agent is considered
                               active and the sandbox stays Running.
+                            maxLength: 512
                             type: string
                           probe:
                             description: |-
@@ -109,6 +112,30 @@ spec:
                   resume:
                     description: Resume defines the resume policy for the sandbox.
                     properties:
+                      onIngressTraffic:
+                        description: |-
+                          OnIngressTraffic resumes the sandbox when the sandbox-gateway receives
+                          inbound traffic addressed to it while it is paused. Unlike the probed
+                          rules this one is event-driven: it needs no probe, it produces no
+                          Status.Schedules entry, and it is executed by the sandbox-gateway rather
+                          than by the sandbox controller.
+                        properties:
+                          pauseTimeout:
+                            description: |-
+                              PauseTimeout is the auto-pause timeout re-armed by a traffic wake: the
+                              gateway writes Spec.PauseTime = now + PauseTimeout atomically with
+                              Spec.Paused = false, so the woken sandbox has running time before its
+                              next auto-pause. It applies only to auto-pause sandboxes (those that
+                              already carry Spec.PauseTime); never-timeout and shutdown-only
+                              sandboxes keep their timeout mode unchanged.
+                              When absent or non-positive, a traffic wake does not re-arm auto-pause:
+                              the woken sandbox keeps running until it is paused or deleted again.
+                              A positive value is subject to the resume timeout floor
+                              (timeout.DefaultMinResumeTimeoutSeconds, currently 300s): values below
+                              the floor are raised to it so the fresh PauseTime cannot expire while
+                              the sandbox is still resuming.
+                            type: string
+                        type: object
                       whenProbedScheduleTime:
                         description: |-
                           WhenProbedScheduleTime resumes the sandbox before a scheduled task
@@ -295,6 +322,8 @@ spec:
                       description: |-
                         Name is the unique identifier for this probe within the sandbox.
                         Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      maxLength: 299
+                      pattern: ^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
                       type: string
                     periodSeconds:
                       description: |-
@@ -351,8 +380,11 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               replicas:
                 description: Replicas is the number of unused sandboxes, including
                   available and creating ones.
@@ -379,16 +411,23 @@ spec:
                     - type: integer
                     - type: string
                     description: |-
-                      MaxUnavailable caps the number of unavailable sandboxes during scale-up.
-                      It can be an absolute number (ex: 5) or a percentage of desired pods
-                      (ex: 10%); percentages are rounded up. Every non-Available sandbox counts
-                      against the physical scale-up budget. If unset or invalid, the controller
-                      uses the base (equivalent to 100%, i.e. no cap).
+                      MaxUnavailable caps concurrent physical scale-up operations and serves as
+                      the startup budget for the ScalingLimited condition. It can be an absolute
+                      number (ex: 5) or a percentage of desired pods (ex: 10%); percentages are
+                      rounded up against spec.replicas. If unset or invalid, the controller uses
+                      the base (equivalent to 100%, i.e. no cap). Scale-down is unaffected.
 
-                      The ScalingLimited condition uses the same resolved value as a separate
-                      startup budget and becomes True with reason StartupBudgetExhausted when
-                      definitive startup failures plus pending-timeout sandboxes exhaust it.
-                      Scale-down is unaffected.
+                      The physical scale-up budget is charged by startup blockers: sandboxes
+                      whose Ready condition is False with reason PodCreateFailed or
+                      StartContainerFailed, sandboxes stuck in Creating/ResourcePending past the
+                      configured --max-pending-timeout, and sandbox creations that have been
+                      issued but are not yet observed by the controller (they release their slot
+                      once observed as healthy Creating sandboxes). Healthy observed Creating
+                      sandboxes do NOT count against the budget.
+
+                      The ScalingLimited condition becomes True with reason
+                      StartupBudgetExhausted when failed plus pending-timeout sandboxes exhaust
+                      the resolved startup budget.
                       MaxUnavailable works only for scale-up.
                     x-kubernetes-int-or-string: true
                 type: object

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxtemplates.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxtemplates.yaml
@@ -63,6 +63,7 @@ spec:
                               Condition message (stdout). When the message matches, the Agent is
                               considered inactive. When it does not match, the Agent is considered
                               active and the sandbox stays Running.
+                            maxLength: 512
                             type: string
                           probe:
                             description: |-
@@ -89,6 +90,30 @@ spec:
                   resume:
                     description: Resume defines the resume policy for the sandbox.
                     properties:
+                      onIngressTraffic:
+                        description: |-
+                          OnIngressTraffic resumes the sandbox when the sandbox-gateway receives
+                          inbound traffic addressed to it while it is paused. Unlike the probed
+                          rules this one is event-driven: it needs no probe, it produces no
+                          Status.Schedules entry, and it is executed by the sandbox-gateway rather
+                          than by the sandbox controller.
+                        properties:
+                          pauseTimeout:
+                            description: |-
+                              PauseTimeout is the auto-pause timeout re-armed by a traffic wake: the
+                              gateway writes Spec.PauseTime = now + PauseTimeout atomically with
+                              Spec.Paused = false, so the woken sandbox has running time before its
+                              next auto-pause. It applies only to auto-pause sandboxes (those that
+                              already carry Spec.PauseTime); never-timeout and shutdown-only
+                              sandboxes keep their timeout mode unchanged.
+                              When absent or non-positive, a traffic wake does not re-arm auto-pause:
+                              the woken sandbox keeps running until it is paused or deleted again.
+                              A positive value is subject to the resume timeout floor
+                              (timeout.DefaultMinResumeTimeoutSeconds, currently 300s): values below
+                              the floor are raised to it so the fresh PauseTime cannot expire while
+                              the sandbox is still resuming.
+                            type: string
+                        type: object
                       whenProbedScheduleTime:
                         description: |-
                           WhenProbedScheduleTime resumes the sandbox before a scheduled task
@@ -275,6 +300,8 @@ spec:
                       description: |-
                         Name is the unique identifier for this probe within the sandbox.
                         Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      maxLength: 299
+                      pattern: ^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
                       type: string
                     periodSeconds:
                       description: |-
@@ -331,8 +358,11 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               runtimes:
                 description: Runtimes - Runtime configuration for sandbox object
                 items:

--- a/versions/kruise-agents-sandbox-controller/next/templates/service.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ include "sandbox-controller.namespace" . }}
   labels:
     {{- include "sandbox-controller.labels" . | nindent 4 }}
+    control-plane: sandbox-controller-manager
 spec:
   ports:
     - name: https-webhook

--- a/versions/kruise-agents-sandbox-manager/next/templates/envoy-config.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/envoy-config.yaml
@@ -56,7 +56,7 @@ data:
                                 prefix: "/"
                               route:
                                 cluster: sbx_original_dst_cluster
-                                timeout: 600s
+                                timeout: 400s
                     http_filters:
                       - name: envoy.filters.http.ext_proc
                         typed_config:
@@ -64,6 +64,7 @@ data:
                           grpc_service:
                             envoy_grpc:
                               cluster_name: ext_proc_cluster
+                          message_timeout: 5s
                           processing_mode:
                             request_header_mode: SEND
                             response_header_mode: SEND
@@ -79,7 +80,7 @@ data:
           type: STATIC
           connect_timeout: 5s
           http2_protocol_options:
-            max_concurrent_streams: {{ .Values.controller.extProcMaxConcurrency }}
+            max_concurrent_streams: 10000
           load_assignment:
             cluster_name: ext_proc_cluster
             endpoints:

--- a/versions/kruise-agents-sandbox-manager/next/templates/gateway-envoy-config.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/gateway-envoy-config.yaml
@@ -16,6 +16,7 @@ data:
     static_resources:
       listeners:
         - name: listener_0
+          per_connection_buffer_limit_bytes: 1048576
           address:
             socket_address:
               address: {{ .Values.gateway.envoy.listener.address }}
@@ -36,18 +37,34 @@ data:
                             start_time: "%START_TIME%"
                             method: "%REQ(:METHOD)%"
                             path: "%REQ(:PATH)%"
-                            protocol: "%PROTOCOL%"
-                            response_code: "%RESPONSE_CODE%"
-                            response_flags: "%RESPONSE_FLAGS%"
-                            bytes_received: "%BYTES_RECEIVED%"
-                            bytes_sent: "%BYTES_SENT%"
-                            duration_ms: "%DURATION%"
-                            upstream_host: "%UPSTREAM_HOST%"
-                            downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
                             user_agent: "%REQ(USER-AGENT)%"
                             request_id: "%REQ(X-REQUEST-ID)%"
                             authority: "%REQ(:AUTHORITY)%"
+                            protocol: "%PROTOCOL%"
+                            upstream_protocol: "%UPSTREAM_PROTOCOL%"
+                            response_code: "%RESPONSE_CODE%"
+                            response_code_details: "%RESPONSE_CODE_DETAILS%"
+                            response_flags: "%RESPONSE_FLAGS%"
+                            connection_termination_details: "%CONNECTION_TERMINATION_DETAILS%"
+                            duration_ms: "%DURATION%"
+                            request_duration_ms: "%REQUEST_DURATION%"
+                            request_tx_duration_ms: "%REQUEST_TX_DURATION%"
+                            response_duration_ms: "%RESPONSE_DURATION%"
+                            response_tx_duration_ms: "%RESPONSE_TX_DURATION%"
+                            bytes_received: "%BYTES_RECEIVED%"
+                            bytes_sent: "%BYTES_SENT%"
+                            upstream_wire_bytes_sent: "%UPSTREAM_WIRE_BYTES_SENT%"
+                            upstream_wire_bytes_received: "%UPSTREAM_WIRE_BYTES_RECEIVED%"
+                            downstream_wire_bytes_sent: "%DOWNSTREAM_WIRE_BYTES_SENT%"
+                            downstream_wire_bytes_received: "%DOWNSTREAM_WIRE_BYTES_RECEIVED%"
+                            route_name: "%ROUTE_NAME%"
+                            upstream_cluster: "%UPSTREAM_CLUSTER%"
+                            upstream_host: "%UPSTREAM_HOST%"
                             upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+                            upstream_request_attempt_count: "%UPSTREAM_REQUEST_ATTEMPT_COUNT%"
+                            downstream_local_address: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                            downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+                            requested_server_name: "%REQUESTED_SERVER_NAME%"
                     route_config:
                       name: local_route
                       virtual_hosts:
@@ -55,10 +72,15 @@ data:
                           domains: ["*"]
                           routes:
                             - match:
+                                prefix: "/kruise/api"
+                              route:
+                                cluster: manager_cluster
+                                timeout: 600s
+                            - match:
                                 prefix: "/"
                               route:
                                 cluster: original_dst_cluster
-                                timeout: 600s
+                                timeout: 0s
                     http_filters:
                       - name: envoy.filters.http.golang
                         typed_config:
@@ -73,17 +95,56 @@ data:
                               sandbox-header-name: {{ .Values.gateway.envoy.pluginConfig.sandboxHeaderName }}
                               sandbox-port-header: {{ .Values.gateway.envoy.pluginConfig.sandboxPortHeader }}
                               default-port: "{{ .Values.gateway.envoy.pluginConfig.defaultPort }}"
+                              enable-auth: false
+                              enable-jwt-auth: false
+                              enable-runtime-mtls: false
+                              traffic-access-token-header: e2b-traffic-access-token
+                              enable-wake-on-traffic: true
+                              wake-timeout-seconds: 60
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                     upgrade_configs:
                       - upgrade_type: websocket
+        - name: listener_prometheus
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9902
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: prometheus
+                    route_config:
+                      name: prometheus_route
+                      virtual_hosts:
+                        - name: prometheus
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                path: /metrics
+                              route:
+                                cluster: admin_cluster
+                                prefix_rewrite: /stats/prometheus
+                                timeout: 30s
+                    http_filters:
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       clusters:
         - name: original_dst_cluster
           type: ORIGINAL_DST
           lb_policy: CLUSTER_PROVIDED
-          common_http_protocol_options:
-            max_requests_per_connection: 1
+          per_connection_buffer_limit_bytes: 1048576
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              common_http_protocol_options:
+                max_requests_per_connection: 1
+              explicit_http_config:
+                http_protocol_options: {}
           connect_timeout: {{ .Values.gateway.envoy.connectTimeout }}
           original_dst_lb_config:
             metadata_key:
@@ -93,11 +154,35 @@ data:
           {{- if .Values.gateway.envoy.circuitBreakers.enabled }}
           circuit_breakers:
             thresholds:
-            {{- range .Values.gateway.envoy.circuitBreakers.thresholds }}
-            - priority: {{ .priority }}
-              max_connections: {{ .maxConnections }}
-              max_pending_requests: {{ .maxPendingRequests }}
-              max_requests: {{ .maxRequests }}
-              max_retries: {{ .maxRetries }}
-            {{- end }}
+            - priority: DEFAULT
+              max_connections: 80000
+              max_pending_requests: 32768
+              max_requests: 80000
+              max_retries: 5
           {{- end }}
+        - name: manager_cluster
+          type: STRICT_DNS
+          lb_policy: ROUND_ROBIN
+          connect_timeout: 5s
+          load_assignment:
+            cluster_name: manager_cluster
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: sandbox-manager.sandbox-system.svc.cluster.local
+                          port_value: 7788
+        - name: admin_cluster
+          type: STATIC
+          connect_timeout: 5s
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: admin_cluster
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 9901

--- a/versions/kruise-agents-sandbox-manager/next/templates/ingress.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/ingress.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "sandbox-manager.fullname" . }}
   labels:
     {{- include "sandbox-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/name: sandbox-manager
+    component: sandbox-manager
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -18,22 +20,12 @@ spec:
         - "{{ .Values.e2b.domain }}"
       secretName: "{{ .Values.ingress.certSecretName }}"
   rules:
-    - host: 'api.{{ .Values.e2b.domain }}'
-      http:
-        paths:
-          - backend:
-              service:
-                name: {{ include "sandbox-manager.fullname" . }}
-                port:
-                  number: 8080
-            path: /
-            pathType: Prefix
     - host: '*.{{ .Values.e2b.domain }}'
       http:
         paths:
           - backend:
               service:
-                name: {{ .Values.ingress.dataplaneService }}
+                name: sandbox-manager
                 port:
                   number: 7788
             path: /
@@ -43,15 +35,15 @@ spec:
         paths:
           - backend:
               service:
-                name: {{ include "sandbox-manager.fullname" . }}
-                port:
-                  number: 8080
-            path: /kruise/api
-            pathType: Prefix
-          - backend:
-              service:
-                name: {{ .Values.ingress.dataplaneService }}
+                name: sandbox-manager
                 port:
                   number: 7788
             path: /
+            pathType: Prefix
+          - backend:
+              service:
+                name: sandbox-manager
+                port:
+                  number: 8080
+            path: /kruise/api
             pathType: Prefix

--- a/versions/kruise-agents-sandbox-manager/next/templates/secret.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/secret.yaml
@@ -8,5 +8,7 @@ metadata:
     "helm.sh/resource-policy": "keep"
   labels:
     {{- include "sandbox-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/name: sandbox-manager
+    component: sandbox-manager
 type: Opaque
 data: {{ if $existing }}{{ toJson $existing.data }}{{ else }}{}{{ end }}

--- a/versions/kruise-agents-sandbox-manager/next/templates/service.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "sandbox-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/name: sandbox-manager
+    component: sandbox-manager
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
## Summary

Re-sync of the unreleased `next/` directories for `kruise-agents-sandbox-controller`
and `kruise-agents-sandbox-manager` against the agents repo source at
`openkruise/agents@8f835ef60` (branch `sync-charts-drop-deployment`).

Follow-up to #185 (which synced against `6c8feb4e0`). This PR picks up the four
CRDs that changed between `bfb0238` and `8f835ef60`, plus the Service/Ingress/
Secret/ConfigMap drift that surfaced under the updated sync-charts skill
(Deployment manifests are now out of scope).

## Source delta (vs. bfb0238 / prior sync baseline)

- `config/crd/bases/agents.kruise.io_poolautoscalers.yaml` (+9)
- `config/crd/bases/agents.kruise.io_sandboxes.yaml` (+44)
- `config/crd/bases/agents.kruise.io_sandboxsets.yaml` (+67)
- `config/crd/bases/agents.kruise.io_sandboxtemplates.yaml` (+32)
- `config/crd/kustomization.yaml` — adds globalsecurityprofiles,
  globaltrafficpolicies, securityprofiles (already in chart mapping)
- `config/webhook/patch_manifests.yaml` — v-pa.kb.io validating webhook
  (already present in chart webhook template; no change required)

## Controller chart changes
- **CRDs**: byte-for-byte sync of poolautoscalers, sandboxes, sandboxsets,
  sandboxtemplates (autoscaling/v1alpha2 additions, sandbox status
  conditions, claim-ref validation).
- **Service**: add `control-plane: sandbox-controller-manager` source label
  alongside the chart helper's standard labels.

## Manager chart changes
- **Service / Ingress / Secret**: override chart helper's
  `app.kubernetes.io/name` and `component` with source-defined
  `sandbox-manager` values; route ingress backends at `sandbox-manager`
  (7788 envoy, 8080 manager) rather than the `dataplaneService` value or
  the `fullname` helper.
- **envoy-config**: route timeout 600s → 400s; add `message_timeout: 5s` on
  the ext_proc filter (source guards against flaky 504s during manager
  CPU throttling); set `max_concurrent_streams` to source-fixed 10000.
- **gateway-envoy-config**: rewrite to source structure —
  `per_connection_buffer_limit_bytes: 1048576` on listener and
  `original_dst_cluster`; expanded access_log json_format; `/kruise/api`
  manager route; golang filter with `enable-auth`, `enable-jwt-auth`,
  `enable-runtime-mtls`, `traffic-access-token-header`,
  `enable-wake-on-traffic`, `wake-timeout-seconds`; Prometheus listener
  on port 9902; `typed_extension_protocol_options` on original_dst
  cluster; source-fixed circuit breaker thresholds (80000/32768/80000/5);
  new `manager_cluster` (STRICT_DNS → sandbox-manager.sandbox-system.svc.cluster.local:7788)
  and `admin_cluster` (STATIC → 127.0.0.1:9901).

## Initial drift output (before fixes)

### CRD check (exit 1)
```
DRIFT crd controller agents.kruise.io_poolautoscalers.yaml content
DRIFT crd controller agents.kruise.io_sandboxes.yaml content
DRIFT crd controller agents.kruise.io_sandboxsets.yaml content
DRIFT crd controller agents.kruise.io_sandboxtemplates.yaml content
```

### Manifests check (exit 1)
- controller Service: `control-plane` label drift (sandbox-controller-manager
  vs chart helper agents-sandbox-controller)
- manager Service: `app.kubernetes.io/name` and `component` labels drift
- manager Ingress: labels, backend service name and port drift; wrong
  wildcard backend (`sandbox-gateway` instead of `sandbox-manager`)
- manager Secret: labels drift
- manager ConfigMap (envoy): route timeout, ext_proc `message_timeout`,
  `max_concurrent_streams` drift
- gateway ConfigMap: missing per_connection_buffer_limit_bytes, missing
  `/kruise/api` route, missing golang filter options, missing Prometheus
  listener, missing manager_cluster and admin_cluster, circuit breaker
  thresholds drift

## Final drift output (after fixes)

### CRD check (exit 0)
All 12 CRDs `OK` — every source CRD mapped and byte-identical.

### Manifests check (exit 0)
Only expected `HELM_ONLY` findings remain:
- controller Service: chart-only `app.kubernetes.io/name` label and
  chart-only metrics port (8443)
- manager Service: chart-only manager (8080) and grpc-extproc (9002) ports
- manager Ingress: chart-only `/kruise/api` path on base-domain rule
  (kept for API routing; source base-domain rule only has `/` → 7788)

## CRD-upgrade impact

CRD additions are purely additive (new status conditions, validation
rules for new fields). No existing CRD field was removed or renamed;
no conversion webhook changes. Safe to apply in place on clusters
already running the previous `next/` chart revision.

## Test plan

- [ ] `helm template sandbox-controller <next> --namespace sandbox-system`
      renders cleanly
- [ ] `helm template sandbox-manager <next> --namespace sandbox-system \
      --set ingress.className=nginx --set e2b.adminApiKey=x` renders
      with the new gateway clusters and listener_prometheus
- [ ] Apply the rendered controller chart on a test cluster; verify the
      webhook service carries both the chart helper labels and
      `control-plane: sandbox-controller-manager`
- [ ] Verify gateway routes: wildcard subdomain → sandbox-manager:7788,
      base domain `/kruise/api` → sandbox-manager:8080, base domain
      `/` → sandbox-manager:7788
- [ ] Confirm gateway Prometheus listener responds on :9902/metrics

Note: Deployment manifests are out of scope for the sync-charts checker.
Existing Deployment template edits from prior syncs are preserved but
not re-verified by the drift checker.