### PR TITLE
sync(agents): align next charts with agents config at 04c6ef961

### DIFF
--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_poolautoscalers.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_poolautoscalers.yaml
@@ -163,7 +163,11 @@ spec:
                   - schedule
                   - targetReplicas
                   type: object
+                maxItems: 20
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               maxReplicas:
                 description: |-
                   MaxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
@@ -232,6 +236,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               conditions:
                 description: Conditions is the set of conditions required for this
                   autoscaler to scale its target.
@@ -333,6 +340,8 @@ spec:
             - currentReplicas
             - desiredReplicas
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxes.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxes.yaml
@@ -65,8 +65,12 @@ spec:
             properties:
               autoPausePolicy:
                 description: |-
-                  AutoPausePolicy defines pause/resume decision rules based on probe
-                  Conditions. Probes are defined in Spec.Probes.
+                  AutoPausePolicy defines when the sandbox controller pauses or resumes
+                  the sandbox. Probe-driven rules reference probes declared in
+                  Spec.Probes and read their results (mirrored from
+                  Pod.Status.Conditions to SandboxStatus.Conditions); the
+                  OnIngressTraffic resume rule is event-driven and does not require a
+                  probe.
                 properties:
                   pause:
                     description: Pause defines the pause policy for the sandbox.
@@ -82,6 +86,7 @@ spec:
                               Condition message (stdout). When the message matches, the Agent is
                               considered inactive. When it does not match, the Agent is considered
                               active and the sandbox stays Running.
+                            maxLength: 512
                             type: string
                           probe:
                             description: |-
@@ -108,6 +113,30 @@ spec:
                   resume:
                     description: Resume defines the resume policy for the sandbox.
                     properties:
+                      onIngressTraffic:
+                        description: |-
+                          OnIngressTraffic resumes the sandbox when the sandbox-gateway receives
+                          inbound traffic addressed to it while it is paused. Unlike the probed
+                          rules this one is event-driven: it needs no probe, it produces no
+                          Status.Schedules entry, and it is executed by the sandbox-gateway rather
+                          than by the sandbox controller.
+                        properties:
+                          pauseTimeout:
+                            description: |-
+                              PauseTimeout is the auto-pause timeout re-armed by a traffic wake: the
+                              gateway writes Spec.PauseTime = now + PauseTimeout atomically with
+                              Spec.Paused = false, so the woken sandbox has running time before its
+                              next auto-pause. It applies only to auto-pause sandboxes (those that
+                              already carry Spec.PauseTime); never-timeout and shutdown-only
+                              sandboxes keep their timeout mode unchanged.
+                              When absent or non-positive, a traffic wake does not re-arm auto-pause:
+                              the woken sandbox keeps running until it is paused or deleted again.
+                              A positive value is subject to the resume timeout floor
+                              (timeout.DefaultMinResumeTimeoutSeconds, currently 300s): values below
+                              the floor are raised to it so the fresh PauseTime cannot expire while
+                              the sandbox is still resuming.
+                            type: string
+                        type: object
                       whenProbedScheduleTime:
                         description: |-
                           WhenProbedScheduleTime resumes the sandbox before a scheduled task
@@ -369,6 +398,8 @@ spec:
                       description: |-
                         Name is the unique identifier for this probe within the sandbox.
                         Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      maxLength: 299
+                      pattern: ^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
                       type: string
                     periodSeconds:
                       description: |-
@@ -425,7 +456,11 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 16
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               runtimes:
                 description: Runtimes - Runtime configuration for sandbox object
                 items:
@@ -630,8 +665,13 @@ spec:
                         Examples: "probedIdle" (pause triggered by WhenProbedIdleState),
                         "probedSchedule" (resume triggered by WhenProbedScheduleTime).
                       type: string
+                  required:
+                  - reason
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - reason
+                x-kubernetes-list-type: map
               updateRevision:
                 description: UpdateRevision is the template-hash calculated from `spec.template`.
                 type: string

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxsets.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxsets.yaml
@@ -64,10 +64,12 @@ spec:
               autoPausePolicy:
                 description: |-
                   AutoPausePolicy defines the pause/resume decision rules for sandboxes
-                  created from this SandboxSet. Its rules reference probes by name, so it is
-                  normally set together with spec.probes. It is copied verbatim onto each
-                  created Sandbox and is part of the update revision hash, so changing it
-                  triggers a rolling update of already-created pool sandboxes.
+                  created from this SandboxSet. Probe-driven rules reference probes by
+                  name (so they are normally set together with spec.probes); the
+                  OnIngressTraffic resume rule is event-driven and does not require a
+                  probe. The policy is copied verbatim onto each created Sandbox and is
+                  part of the update revision hash, so changing it triggers a rolling
+                  update of already-created pool sandboxes.
                 properties:
                   pause:
                     description: Pause defines the pause policy for the sandbox.
@@ -83,6 +85,7 @@ spec:
                               Condition message (stdout). When the message matches, the Agent is
                               considered inactive. When it does not match, the Agent is considered
                               active and the sandbox stays Running.
+                            maxLength: 512
                             type: string
                           probe:
                             description: |-
@@ -109,6 +112,30 @@ spec:
                   resume:
                     description: Resume defines the resume policy for the sandbox.
                     properties:
+                      onIngressTraffic:
+                        description: |-
+                          OnIngressTraffic resumes the sandbox when the sandbox-gateway receives
+                          inbound traffic addressed to it while it is paused. Unlike the probed
+                          rules this one is event-driven: it needs no probe, it produces no
+                          Status.Schedules entry, and it is executed by the sandbox-gateway rather
+                          than by the sandbox controller.
+                        properties:
+                          pauseTimeout:
+                            description: |-
+                              PauseTimeout is the auto-pause timeout re-armed by a traffic wake: the
+                              gateway writes Spec.PauseTime = now + PauseTimeout atomically with
+                              Spec.Paused = false, so the woken sandbox has running time before its
+                              next auto-pause. It applies only to auto-pause sandboxes (those that
+                              already carry Spec.PauseTime); never-timeout and shutdown-only
+                              sandboxes keep their timeout mode unchanged.
+                              When absent or non-positive, a traffic wake does not re-arm auto-pause:
+                              the woken sandbox keeps running until it is paused or deleted again.
+                              A positive value is subject to the resume timeout floor
+                              (timeout.DefaultMinResumeTimeoutSeconds, currently 300s): values below
+                              the floor are raised to it so the fresh PauseTime cannot expire while
+                              the sandbox is still resuming.
+                            type: string
+                        type: object
                       whenProbedScheduleTime:
                         description: |-
                           WhenProbedScheduleTime resumes the sandbox before a scheduled task
@@ -295,6 +322,8 @@ spec:
                       description: |-
                         Name is the unique identifier for this probe within the sandbox.
                         Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      maxLength: 299
+                      pattern: ^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
                       type: string
                     periodSeconds:
                       description: |-
@@ -351,8 +380,11 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               replicas:
                 description: Replicas is the number of unused sandboxes, including
                   available and creating ones.
@@ -379,16 +411,23 @@ spec:
                     - type: integer
                     - type: string
                     description: |-
-                      MaxUnavailable caps the number of unavailable sandboxes during scale-up.
-                      It can be an absolute number (ex: 5) or a percentage of desired pods
-                      (ex: 10%); percentages are rounded up. Every non-Available sandbox counts
-                      against the physical scale-up budget. If unset or invalid, the controller
-                      uses the base (equivalent to 100%, i.e. no cap).
+                      MaxUnavailable caps concurrent physical scale-up operations and serves as
+                      the startup budget for the ScalingLimited condition. It can be an absolute
+                      number (ex: 5) or a percentage of desired pods (ex: 10%); percentages are
+                      rounded up against spec.replicas. If unset or invalid, the controller uses
+                      the base (equivalent to 100%, i.e. no cap). Scale-down is unaffected.
 
-                      The ScalingLimited condition uses the same resolved value as a separate
-                      startup budget and becomes True with reason StartupBudgetExhausted when
-                      definitive startup failures plus pending-timeout sandboxes exhaust it.
-                      Scale-down is unaffected.
+                      The physical scale-up budget is charged by startup blockers: sandboxes
+                      whose Ready condition is False with reason PodCreateFailed or
+                      StartContainerFailed, sandboxes stuck in Creating/ResourcePending past the
+                      configured --max-pending-timeout, and sandbox creations that have been
+                      issued but are not yet observed by the controller (they release their slot
+                      once observed as healthy Creating sandboxes). Healthy observed Creating
+                      sandboxes do NOT count against the budget.
+
+                      The ScalingLimited condition becomes True with reason
+                      StartupBudgetExhausted when failed plus pending-timeout sandboxes exhaust
+                      the resolved startup budget.
                       MaxUnavailable works only for scale-up.
                     x-kubernetes-int-or-string: true
                 type: object

--- a/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxtemplates.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxtemplates.yaml
@@ -63,6 +63,7 @@ spec:
                               Condition message (stdout). When the message matches, the Agent is
                               considered inactive. When it does not match, the Agent is considered
                               active and the sandbox stays Running.
+                            maxLength: 512
                             type: string
                           probe:
                             description: |-
@@ -89,6 +90,30 @@ spec:
                   resume:
                     description: Resume defines the resume policy for the sandbox.
                     properties:
+                      onIngressTraffic:
+                        description: |-
+                          OnIngressTraffic resumes the sandbox when the sandbox-gateway receives
+                          inbound traffic addressed to it while it is paused. Unlike the probed
+                          rules this one is event-driven: it needs no probe, it produces no
+                          Status.Schedules entry, and it is executed by the sandbox-gateway rather
+                          than by the sandbox controller.
+                        properties:
+                          pauseTimeout:
+                            description: |-
+                              PauseTimeout is the auto-pause timeout re-armed by a traffic wake: the
+                              gateway writes Spec.PauseTime = now + PauseTimeout atomically with
+                              Spec.Paused = false, so the woken sandbox has running time before its
+                              next auto-pause. It applies only to auto-pause sandboxes (those that
+                              already carry Spec.PauseTime); never-timeout and shutdown-only
+                              sandboxes keep their timeout mode unchanged.
+                              When absent or non-positive, a traffic wake does not re-arm auto-pause:
+                              the woken sandbox keeps running until it is paused or deleted again.
+                              A positive value is subject to the resume timeout floor
+                              (timeout.DefaultMinResumeTimeoutSeconds, currently 300s): values below
+                              the floor are raised to it so the fresh PauseTime cannot expire while
+                              the sandbox is still resuming.
+                            type: string
+                        type: object
                       whenProbedScheduleTime:
                         description: |-
                           WhenProbedScheduleTime resumes the sandbox before a scheduled task
@@ -275,6 +300,8 @@ spec:
                       description: |-
                         Name is the unique identifier for this probe within the sandbox.
                         Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      maxLength: 299
+                      pattern: ^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
                       type: string
                     periodSeconds:
                       description: |-
@@ -331,8 +358,11 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               runtimes:
                 description: Runtimes - Runtime configuration for sandbox object
                 items:

--- a/versions/kruise-agents-sandbox-controller/next/templates/service.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ include "sandbox-controller.namespace" . }}
   labels:
     {{- include "sandbox-controller.labels" . | nindent 4 }}
+    control-plane: sandbox-controller-manager
 spec:
   ports:
     - name: https-webhook

--- a/versions/kruise-agents-sandbox-manager/next/templates/envoy-config.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/envoy-config.yaml
@@ -56,7 +56,7 @@ data:
                                 prefix: "/"
                               route:
                                 cluster: sbx_original_dst_cluster
-                                timeout: 600s
+                                timeout: 400s
                     http_filters:
                       - name: envoy.filters.http.ext_proc
                         typed_config:
@@ -64,6 +64,7 @@ data:
                           grpc_service:
                             envoy_grpc:
                               cluster_name: ext_proc_cluster
+                          message_timeout: 5s
                           processing_mode:
                             request_header_mode: SEND
                             response_header_mode: SEND
@@ -79,7 +80,7 @@ data:
           type: STATIC
           connect_timeout: 5s
           http2_protocol_options:
-            max_concurrent_streams: {{ .Values.controller.extProcMaxConcurrency }}
+            max_concurrent_streams: 10000
           load_assignment:
             cluster_name: ext_proc_cluster
             endpoints:

--- a/versions/kruise-agents-sandbox-manager/next/templates/gateway-envoy-config.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/gateway-envoy-config.yaml
@@ -16,6 +16,7 @@ data:
     static_resources:
       listeners:
         - name: listener_0
+          per_connection_buffer_limit_bytes: 1048576
           address:
             socket_address:
               address: {{ .Values.gateway.envoy.listener.address }}
@@ -36,18 +37,34 @@ data:
                             start_time: "%START_TIME%"
                             method: "%REQ(:METHOD)%"
                             path: "%REQ(:PATH)%"
-                            protocol: "%PROTOCOL%"
-                            response_code: "%RESPONSE_CODE%"
-                            response_flags: "%RESPONSE_FLAGS%"
-                            bytes_received: "%BYTES_RECEIVED%"
-                            bytes_sent: "%BYTES_SENT%"
-                            duration_ms: "%DURATION%"
-                            upstream_host: "%UPSTREAM_HOST%"
-                            downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
                             user_agent: "%REQ(USER-AGENT)%"
                             request_id: "%REQ(X-REQUEST-ID)%"
                             authority: "%REQ(:AUTHORITY)%"
+                            protocol: "%PROTOCOL%"
+                            upstream_protocol: "%UPSTREAM_PROTOCOL%"
+                            response_code: "%RESPONSE_CODE%"
+                            response_code_details: "%RESPONSE_CODE_DETAILS%"
+                            response_flags: "%RESPONSE_FLAGS%"
+                            connection_termination_details: "%CONNECTION_TERMINATION_DETAILS%"
+                            duration_ms: "%DURATION%"
+                            request_duration_ms: "%REQUEST_DURATION%"
+                            request_tx_duration_ms: "%REQUEST_TX_DURATION%"
+                            response_duration_ms: "%RESPONSE_DURATION%"
+                            response_tx_duration_ms: "%RESPONSE_TX_DURATION%"
+                            bytes_received: "%BYTES_RECEIVED%"
+                            bytes_sent: "%BYTES_SENT%"
+                            upstream_wire_bytes_sent: "%UPSTREAM_WIRE_BYTES_SENT%"
+                            upstream_wire_bytes_received: "%UPSTREAM_WIRE_BYTES_RECEIVED%"
+                            downstream_wire_bytes_sent: "%DOWNSTREAM_WIRE_BYTES_SENT%"
+                            downstream_wire_bytes_received: "%DOWNSTREAM_WIRE_BYTES_RECEIVED%"
+                            route_name: "%ROUTE_NAME%"
+                            upstream_cluster: "%UPSTREAM_CLUSTER%"
+                            upstream_host: "%UPSTREAM_HOST%"
                             upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+                            upstream_request_attempt_count: "%UPSTREAM_REQUEST_ATTEMPT_COUNT%"
+                            downstream_local_address: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                            downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+                            requested_server_name: "%REQUESTED_SERVER_NAME%"
                     route_config:
                       name: local_route
                       virtual_hosts:
@@ -55,10 +72,15 @@ data:
                           domains: ["*"]
                           routes:
                             - match:
+                                prefix: "/kruise/api"
+                              route:
+                                cluster: manager_cluster
+                                timeout: 600s
+                            - match:
                                 prefix: "/"
                               route:
                                 cluster: original_dst_cluster
-                                timeout: 600s
+                                timeout: 0s
                     http_filters:
                       - name: envoy.filters.http.golang
                         typed_config:
@@ -73,17 +95,56 @@ data:
                               sandbox-header-name: {{ .Values.gateway.envoy.pluginConfig.sandboxHeaderName }}
                               sandbox-port-header: {{ .Values.gateway.envoy.pluginConfig.sandboxPortHeader }}
                               default-port: "{{ .Values.gateway.envoy.pluginConfig.defaultPort }}"
+                              enable-auth: false
+                              enable-jwt-auth: false
+                              enable-runtime-mtls: false
+                              traffic-access-token-header: e2b-traffic-access-token
+                              enable-wake-on-traffic: true
+                              wake-timeout-seconds: 60
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                     upgrade_configs:
                       - upgrade_type: websocket
+        - name: listener_prometheus
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9902
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: prometheus
+                    route_config:
+                      name: prometheus_route
+                      virtual_hosts:
+                        - name: prometheus
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                path: /metrics
+                              route:
+                                cluster: admin_cluster
+                                prefix_rewrite: /stats/prometheus
+                                timeout: 30s
+                    http_filters:
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       clusters:
         - name: original_dst_cluster
           type: ORIGINAL_DST
           lb_policy: CLUSTER_PROVIDED
-          common_http_protocol_options:
-            max_requests_per_connection: 1
+          per_connection_buffer_limit_bytes: 1048576
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              common_http_protocol_options:
+                max_requests_per_connection: 1
+              explicit_http_config:
+                http_protocol_options: {}
           connect_timeout: {{ .Values.gateway.envoy.connectTimeout }}
           original_dst_lb_config:
             metadata_key:
@@ -93,11 +154,35 @@ data:
           {{- if .Values.gateway.envoy.circuitBreakers.enabled }}
           circuit_breakers:
             thresholds:
-            {{- range .Values.gateway.envoy.circuitBreakers.thresholds }}
-            - priority: {{ .priority }}
-              max_connections: {{ .maxConnections }}
-              max_pending_requests: {{ .maxPendingRequests }}
-              max_requests: {{ .maxRequests }}
-              max_retries: {{ .maxRetries }}
-            {{- end }}
+            - priority: DEFAULT
+              max_connections: 80000
+              max_pending_requests: 32768
+              max_requests: 80000
+              max_retries: 5
           {{- end }}
+        - name: manager_cluster
+          type: STRICT_DNS
+          lb_policy: ROUND_ROBIN
+          connect_timeout: 5s
+          load_assignment:
+            cluster_name: manager_cluster
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: sandbox-manager.sandbox-system.svc.cluster.local
+                          port_value: 7788
+        - name: admin_cluster
+          type: STATIC
+          connect_timeout: 5s
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: admin_cluster
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 9901

--- a/versions/kruise-agents-sandbox-manager/next/templates/ingress.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/ingress.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "sandbox-manager.fullname" . }}
   labels:
     {{- include "sandbox-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/name: sandbox-manager
+    component: sandbox-manager
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -18,22 +20,12 @@ spec:
         - "{{ .Values.e2b.domain }}"
       secretName: "{{ .Values.ingress.certSecretName }}"
   rules:
-    - host: 'api.{{ .Values.e2b.domain }}'
-      http:
-        paths:
-          - backend:
-              service:
-                name: {{ include "sandbox-manager.fullname" . }}
-                port:
-                  number: 8080
-            path: /
-            pathType: Prefix
     - host: '*.{{ .Values.e2b.domain }}'
       http:
         paths:
           - backend:
               service:
-                name: {{ .Values.ingress.dataplaneService }}
+                name: sandbox-manager
                 port:
                   number: 7788
             path: /
@@ -43,15 +35,15 @@ spec:
         paths:
           - backend:
               service:
-                name: {{ include "sandbox-manager.fullname" . }}
-                port:
-                  number: 8080
-            path: /kruise/api
-            pathType: Prefix
-          - backend:
-              service:
-                name: {{ .Values.ingress.dataplaneService }}
+                name: sandbox-manager
                 port:
                   number: 7788
             path: /
+            pathType: Prefix
+          - backend:
+              service:
+                name: sandbox-manager
+                port:
+                  number: 8080
+            path: /kruise/api
             pathType: Prefix

--- a/versions/kruise-agents-sandbox-manager/next/templates/secret.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/secret.yaml
@@ -8,5 +8,7 @@ metadata:
     "helm.sh/resource-policy": "keep"
   labels:
     {{- include "sandbox-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/name: sandbox-manager
+    component: sandbox-manager
 type: Opaque
 data: {{ if $existing }}{{ toJson $existing.data }}{{ else }}{}{{ end }}

--- a/versions/kruise-agents-sandbox-manager/next/templates/service.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "sandbox-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/name: sandbox-manager
+    component: sandbox-manager
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
## Summary

Sync unreleased `next/` chart content from the OpenKruise Agents repository at commit `04c6ef961` on the `sync-charts-drop-deployment` branch.

### Changes

- **CRDs**: updated `poolautoscalers`, `sandboxes`, `sandboxsets`, and `sandboxtemplates` CRDs to match the generated source byte-for-byte.
- **Controller Service**: preserved the source `control-plane: sandbox-controller-manager` label.
- **Manager Service / Ingress / Secret**: preserved source `app.kubernetes.io/name: sandbox-manager` and `component: sandbox-manager` labels; restructured Ingress rules so the first two rules match the source routing while retaining the chart-only `/kruise/api` path.
- **Manager envoy-config**: aligned listener/cluster fields with the source, including `message_timeout: 5s` for ext_proc and `max_concurrent_streams: 10000` for the ext_proc cluster.
- **Gateway envoy-config**: aligned listener buffer limits, access log format, routes, clusters, and circuit breaker thresholds with the source.

### Verification

- `chart_drift.py --aspect crd`: all CRDs mapped and byte-identical.
- `chart_drift.py --aspect manifests --component all`: only expected `HELM_ONLY` findings remain; no `DRIFT`, `MISSING`, or `UNMAPPED`.
- Controller webhook, RBAC, and identity resources reviewed for parity.
- Both charts render successfully with `helm template`.

No chart versions or release pointers were changed.