### PR TITLE
feat(kruise-game): make controller-manager imagePullSecrets and scheduling configurable

### DIFF
--- a/versions/kruise-game/next/templates/manager.yaml
+++ b/versions/kruise-game/next/templates/manager.yaml
@@ -42,6 +42,22 @@ spec:
       labels:
         control-plane: {{ .Values.kruiseGame.fullname }}
     spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.kruiseGame.affinity }}
+      affinity:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- if .Values.kruiseGame.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.kruiseGame.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.kruiseGame.tolerations }}
+      tolerations:
+{{ toYaml .Values.kruiseGame.tolerations | indent 8 }}
+{{- end }}
       #      securityContext:
       #        runAsNonRoot: true
       # TODO(user): For common cases that do not require escalating privileges

--- a/versions/kruise-game/next/values.yaml
+++ b/versions/kruise-game/next/values.yaml
@@ -15,6 +15,29 @@ kruiseGame:
     targetPort: 9876
   apiServerQps: 5
   apiServerQpsBurst: 10
+  # node selector for the controller-manager Pod
+  nodeSelector: {}
+  # tolerations for the controller-manager Pod
+  tolerations: []
+  # affinity rules for the controller-manager Pod
+  # for example, to spread replicas across different nodes:
+  # affinity:
+  #   podAntiAffinity:
+  #     preferredDuringSchedulingIgnoredDuringExecution:
+  #       - podAffinityTerm:
+  #           labelSelector:
+  #             matchExpressions:
+  #               - key: control-plane
+  #                 operator: In
+  #                 values:
+  #                   - kruise-game-controller-manager
+  #           topologyKey: kubernetes.io/hostname
+  #         weight: 100
+  affinity: {}
+
+# imagePullSecrets to pull the controller-manager image
+imagePullSecrets: []
+#  - name: my-registry-secret
 
 replicaCount: 1
 


### PR DESCRIPTION
## What this PR does

Adds four optional knobs to the `kruise-game` next chart, so users can control how the controller-manager Pod is scheduled and where its image is pulled from:

- top-level `imagePullSecrets`
- `kruiseGame.nodeSelector`
- `kruiseGame.tolerations`
- `kruiseGame.affinity`

The `affinity` value carries a commented, copy-pasteable podAntiAffinity example that spreads replicas across nodes, mirroring the default behavior of the main `kruise` chart.

## Why

Users running private registries or heterogeneous clusters currently have to fork or post-process the rendered manifests to add an image pull secret or to pin the controller-manager to specific nodes. These are the same knobs the main `kruise` chart already exposes, so this also makes the two charts consistent.

## Backward compatibility

All four values default to empty (`[]` / `{}`) and the templates only render the fields when they are non-empty, so the default rendered manifests are **byte-for-byte identical** to before this PR.

Verified with `helm template`:

- default values → no `imagePullSecrets` / `affinity` / `nodeSelector` / `tolerations` rendered
- all four set → each appears correctly in the Deployment pod spec, with `affinity` rendered as-is (users own the whole value, no hidden merging)
