### PR TITLE
feat(kruise): make image pullPolicy configurable and add imagePullSecrets to pre-delete hook

### DIFF
--- a/versions/kruise/next/templates/manager.yaml
+++ b/versions/kruise/next/templates/manager.yaml
@@ -72,7 +72,7 @@ spec:
           command:
             - /manager
           image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           securityContext:
             capabilities:
               drop:
@@ -226,7 +226,7 @@ spec:
         - --plugin-bin-dir=/credential-provider-plugin
 {{- end }}
         image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
         securityContext:
           capabilities:
             drop:

--- a/versions/kruise/next/templates/pre_delete_hook_job.yaml
+++ b/versions/kruise/next/templates/pre_delete_hook_job.yaml
@@ -73,12 +73,16 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         kruise: helm-finalizer
     spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 6 }}
+{{- end }}
       restartPolicy: Never
       serviceAccountName: kruise-helm-hook
       containers:
         - name: pre-delete-job
           image: {{ .Values.helmHooks.image.repository }}:{{ .Values.helmHooks.image.tag }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.helmHooks.image.pullPolicy }}
 ---
 # write a service account named kruise-helm-hook:
 apiVersion: v1

--- a/versions/kruise/next/values.yaml
+++ b/versions/kruise/next/values.yaml
@@ -33,6 +33,7 @@ manager:
   image:
     repository: openkruise/kruise-manager
     tag: v1.9.0
+    pullPolicy: Always
   webhook:
     port: 9876
   metrics:
@@ -121,3 +122,4 @@ helmHooks:
   image:
     repository: openkruise/kruise-helm-hook
     tag: v0.1.0
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
## What this PR does

Makes the image pull behavior of the `kruise` next chart configurable instead of hardcoded:

- `manager.image.pullPolicy` (default `Always`) — now used by both the kruise-manager Deployment and the kruise-daemon DaemonSet, which already share `manager.image.repository/tag`
- `helmHooks.image.pullPolicy` (default `IfNotPresent`) — used by the pre-delete finalizer Job
- the pre-delete hook Job now honors the top-level `imagePullSecrets`, so it can pull the hook image from private registries

## Why

Users running private registries or air-gapped clusters currently have to fork or post-process the chart:

- the hardcoded `imagePullPolicy: Always` forces a registry round-trip on every Pod start, which fails outright when the registry is unreachable and the image is already cached locally
- the pre-delete hook Job could not use `imagePullSecrets` at all, so uninstalling kruise fails on private registries

## Backward compatibility

The defaults equal the previously hardcoded values (`Always` for the manager, `IfNotPresent` for the hook), so the default rendered manifests are byte-for-byte identical to before.

Verified with `helm template`:

- default values → `imagePullPolicy: Always` for manager and daemon, `IfNotPresent` for the hook Job, no `imagePullSecrets` rendered
- `manager.image.pullPolicy: IfNotPresent` + `helmHooks.image.pullPolicy: Always` + top-level `imagePullSecrets` → all rendered correctly, including the pre-delete Job
