### PR TITLE
feat(sandbox-manager): update charts to enable more options

### DIFF
--- a/versions/kruise-agents-sandbox-controller/next/templates/deployment.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
             - --sandbox-workers={{ .Values.controller.workers.sandboxWorkers }}
             - --sandboxset-workers={{ .Values.controller.workers.sandboxsetWorkers }}
             - --sandboxclaim-workers={{ .Values.controller.workers.sandboxclaimWorkers }}
-            - --checkpoint-workers={{ .Values.controller.workers.checkpointWorkers }}
             - --client-qps={{ .Values.controller.clientQPS }}
             - --client-burst={{ .Values.controller.clientBurst }}
           command:

--- a/versions/kruise-agents-sandbox-controller/next/templates/deployment.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/deployment.yaml
@@ -38,6 +38,12 @@ spec:
             - --leader-elect
             - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
             - --webhook-cert-path=/home/nonroot/sandbox-controller-webhook-certs
+            - --sandbox-workers={{ .Values.controller.workers.sandboxWorkers }}
+            - --sandboxset-workers={{ .Values.controller.workers.sandboxsetWorkers }}
+            - --sandboxclaim-workers={{ .Values.controller.workers.sandboxclaimWorkers }}
+            - --checkpoint-workers={{ .Values.controller.workers.checkpointWorkers }}
+            - --client-qps={{ .Values.controller.clientQPS }}
+            - --client-burst={{ .Values.controller.clientBurst }}
           command:
             - /manager
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/versions/kruise-agents-sandbox-controller/next/values.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/values.yaml
@@ -36,7 +36,6 @@ controller:
     sandboxWorkers: 200
     sandboxsetWorkers: 10
     sandboxclaimWorkers: 200
-    checkpointWorkers: 20
   # Kubernetes API client rate limit
   clientQPS: 30000
   clientBurst: 60000

--- a/versions/kruise-agents-sandbox-controller/next/values.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/values.yaml
@@ -29,6 +29,18 @@ metrics:
 healthProbe:
   port: 8081
 
+# Controller runtime configuration
+controller:
+  # Number of concurrent workers for each reconciler
+  workers:
+    sandboxWorkers: 200
+    sandboxsetWorkers: 10
+    sandboxclaimWorkers: 200
+    checkpointWorkers: 20
+  # Kubernetes API client rate limit
+  clientQPS: 30000
+  clientBurst: 60000
+
 resources:
   limits:
     cpu: "2"

--- a/versions/kruise-agents-sandbox-manager/next/templates/deployment.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/deployment.yaml
@@ -33,7 +33,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork | default false }}
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      {{- if gt (int .Values.gracefulShutdown.preStopSleepSeconds) 0 }}
+      terminationGracePeriodSeconds: {{ add (int .Values.gracefulShutdown.preStopSleepSeconds) 30 }}
+      {{- end }}
       containers:
         - name: controller
           {{- with .Values.securityContext }}
@@ -51,10 +54,13 @@ spec:
             - --peer-selector=agents.kruise.io/sandbox-manager-peer-finder={{ .Release.Name }}
             - --kube-client-qps=10000
             - --kube-client-burst=30000
-            - --e2b-domain={{ .Values.e2b.domain }}
             - --e2b-admin-key={{ required "e2b.adminApiKey is required" .Values.e2b.adminApiKey }}
             - --e2b-enable-auth={{ .Values.e2b.enableAuth }}
             - --e2b-max-timeout={{ int .Values.e2b.maxTimeout }}
+            - --e2b-key-storage={{ .Values.e2b.keyStorage.mode }}
+            - --e2b-key-storage-disable-schema-auto-update
+            - --quota-redis-addr={{ ternary .Values.quota.redis.addr "" .Values.quota.enabled }}
+            - --quota-redis-db={{ int .Values.quota.redis.db }}
             - --max-claim-workers={{ int .Values.controller.maxClaimWorkers }}
             - --max-create-qps={{ int .Values.controller.maxCreateQPS }}
             - --ext-proc-max-concurrency={{ int .Values.controller.extProcMaxConcurrency }}
@@ -87,12 +93,38 @@ spec:
           env:
             - name: INFRA
               value: {{ .Values.controller.infra }}
+            - name: E2B_KEY_STORAGE_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sandbox-manager.fullname" . }}-runtime-config
+                  key: E2B_KEY_STORAGE_DSN
+            - name: E2B_KEY_HASH_PEPPER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sandbox-manager.fullname" . }}-runtime-config
+                  key: E2B_KEY_HASH_PEPPER
+            - name: QUOTA_REDIS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sandbox-manager.fullname" . }}-runtime-config
+                  key: QUOTA_REDIS_USERNAME
+            - name: QUOTA_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sandbox-manager.fullname" . }}-runtime-config
+                  key: QUOTA_REDIS_PASSWORD
           {{- with .Values.controller.resources }}
           resources:
             limits:
               {{- toYaml . | nindent 14 }}
             requests:
               {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- if gt (int .Values.gracefulShutdown.preStopSleepSeconds) 0 }}
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: {{ int .Values.gracefulShutdown.preStopSleepSeconds }}
           {{- end }}
         - name: envoy-proxy
           {{- with .Values.securityContext }}
@@ -130,6 +162,12 @@ spec:
             - name: envoy-config
               mountPath: /etc/envoy/envoy.yaml
               subPath: envoy.yaml
+          {{- if gt (int .Values.gracefulShutdown.preStopSleepSeconds) 0 }}
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: {{ int .Values.gracefulShutdown.preStopSleepSeconds }}
+          {{- end }}
       volumes:
         - name: envoy-config
           configMap:

--- a/versions/kruise-agents-sandbox-manager/next/templates/deployment.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/deployment.yaml
@@ -54,7 +54,6 @@ spec:
             - --peer-selector=agents.kruise.io/sandbox-manager-peer-finder={{ .Release.Name }}
             - --kube-client-qps=10000
             - --kube-client-burst=30000
-            - --e2b-admin-key={{ required "e2b.adminApiKey is required" .Values.e2b.adminApiKey }}
             - --e2b-enable-auth={{ .Values.e2b.enableAuth }}
             - --e2b-max-timeout={{ int .Values.e2b.maxTimeout }}
             - --e2b-key-storage={{ .Values.e2b.keyStorage.mode }}

--- a/versions/kruise-agents-sandbox-manager/next/templates/deployment.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
             - --e2b-key-storage-disable-schema-auto-update
             - --quota-redis-addr={{ ternary .Values.quota.redis.addr "" .Values.quota.enabled }}
             - --quota-redis-db={{ int .Values.quota.redis.db }}
+            - --secret-config={{ include "sandbox-manager.fullname" . }}-runtime-config
             - --max-claim-workers={{ int .Values.controller.maxClaimWorkers }}
             - --max-create-qps={{ int .Values.controller.maxCreateQPS }}
             - --ext-proc-max-concurrency={{ int .Values.controller.extProcMaxConcurrency }}
@@ -93,26 +94,6 @@ spec:
           env:
             - name: INFRA
               value: {{ .Values.controller.infra }}
-            - name: E2B_KEY_STORAGE_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "sandbox-manager.fullname" . }}-runtime-config
-                  key: E2B_KEY_STORAGE_DSN
-            - name: E2B_KEY_HASH_PEPPER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "sandbox-manager.fullname" . }}-runtime-config
-                  key: E2B_KEY_HASH_PEPPER
-            - name: QUOTA_REDIS_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "sandbox-manager.fullname" . }}-runtime-config
-                  key: QUOTA_REDIS_USERNAME
-            - name: QUOTA_REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "sandbox-manager.fullname" . }}-runtime-config
-                  key: QUOTA_REDIS_PASSWORD
           {{- with .Values.controller.resources }}
           resources:
             limits:

--- a/versions/kruise-agents-sandbox-manager/next/templates/gateway-envoy-config.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/gateway-envoy-config.yaml
@@ -16,11 +16,17 @@ data:
     static_resources:
       listeners:
         - name: listener_0
-          per_connection_buffer_limit_bytes: 1048576
+          per_connection_buffer_limit_bytes: {{ int .Values.gateway.envoy.perConnectionBufferLimitBytes }}
           address:
             socket_address:
               address: {{ .Values.gateway.envoy.listener.address }}
               port_value: {{ .Values.gateway.envoy.listener.port }}
+          {{- if .Values.gateway.envoy.tcpKeepalive.enabled }}
+          tcp_keepalive:
+            keepalive_probes: {{ .Values.gateway.envoy.tcpKeepalive.keepaliveProbes }}
+            keepalive_time: {{ .Values.gateway.envoy.tcpKeepalive.keepaliveTime }}
+            keepalive_interval: {{ .Values.gateway.envoy.tcpKeepalive.keepaliveInterval }}
+          {{- end }}
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager
@@ -46,22 +52,26 @@ data:
                             response_code_details: "%RESPONSE_CODE_DETAILS%"
                             response_flags: "%RESPONSE_FLAGS%"
                             connection_termination_details: "%CONNECTION_TERMINATION_DETAILS%"
+
                             duration_ms: "%DURATION%"
                             request_duration_ms: "%REQUEST_DURATION%"
                             request_tx_duration_ms: "%REQUEST_TX_DURATION%"
                             response_duration_ms: "%RESPONSE_DURATION%"
                             response_tx_duration_ms: "%RESPONSE_TX_DURATION%"
+
                             bytes_received: "%BYTES_RECEIVED%"
                             bytes_sent: "%BYTES_SENT%"
                             upstream_wire_bytes_sent: "%UPSTREAM_WIRE_BYTES_SENT%"
                             upstream_wire_bytes_received: "%UPSTREAM_WIRE_BYTES_RECEIVED%"
                             downstream_wire_bytes_sent: "%DOWNSTREAM_WIRE_BYTES_SENT%"
                             downstream_wire_bytes_received: "%DOWNSTREAM_WIRE_BYTES_RECEIVED%"
+
                             route_name: "%ROUTE_NAME%"
                             upstream_cluster: "%UPSTREAM_CLUSTER%"
                             upstream_host: "%UPSTREAM_HOST%"
                             upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
                             upstream_request_attempt_count: "%UPSTREAM_REQUEST_ATTEMPT_COUNT%"
+
                             downstream_local_address: "%DOWNSTREAM_LOCAL_ADDRESS%"
                             downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
                             requested_server_name: "%REQUESTED_SERVER_NAME%"
@@ -97,10 +107,12 @@ data:
                               sandbox-header-name: {{ .Values.gateway.envoy.pluginConfig.sandboxHeaderName }}
                               sandbox-port-header: {{ .Values.gateway.envoy.pluginConfig.sandboxPortHeader }}
                               default-port: "{{ .Values.gateway.envoy.pluginConfig.defaultPort }}"
-                              enable-auth: false
-                              enable-jwt-auth: false
+                              enable-auth: {{ .Values.gateway.envoy.pluginConfig.enableAuth }}
+                              {{- if and .Values.gateway.envoy.pluginConfig.enableAuth .Values.gateway.envoy.pluginConfig.enableJwtAuth }}
+                              enable-jwt-auth: true
+                              traffic-access-token-header: {{ .Values.gateway.envoy.pluginConfig.trafficAccessTokenHeader }}
+                              {{- end }}
                               enable-runtime-mtls: false
-                              traffic-access-token-header: e2b-traffic-access-token
                               enable-wake-on-traffic: true
                               wake-timeout-seconds: 60
                       - name: envoy.filters.http.router
@@ -108,11 +120,12 @@ data:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                     upgrade_configs:
                       - upgrade_type: websocket
+    {{- if .Values.gateway.envoy.prometheus.enabled }}
         - name: listener_prometheus
           address:
             socket_address:
-              address: 0.0.0.0
-              port_value: 9902
+              address: {{ .Values.gateway.envoy.prometheus.address }}
+              port_value: {{ .Values.gateway.envoy.prometheus.port }}
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager
@@ -126,7 +139,7 @@ data:
                           domains: ["*"]
                           routes:
                             - match:
-                                path: /metrics
+                                path: {{ .Values.gateway.envoy.prometheus.path }}
                               route:
                                 cluster: admin_cluster
                                 prefix_rewrite: /stats/prometheus
@@ -135,18 +148,25 @@ data:
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    {{- end }}
       clusters:
         - name: original_dst_cluster
           type: ORIGINAL_DST
           lb_policy: CLUSTER_PROVIDED
-          per_connection_buffer_limit_bytes: 1048576
+          per_connection_buffer_limit_bytes: {{ int .Values.gateway.envoy.perConnectionBufferLimitBytes }}
           typed_extension_protocol_options:
             envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
               "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               common_http_protocol_options:
                 max_requests_per_connection: 1
+              {{- if .Values.gateway.envoy.useDownstreamProtocolConfig }}
+              use_downstream_protocol_config:
+                http_protocol_options: {}
+                http2_protocol_options: {}
+              {{- else }}
               explicit_http_config:
                 http_protocol_options: {}
+              {{- end }}
           connect_timeout: {{ .Values.gateway.envoy.connectTimeout }}
           original_dst_lb_config:
             metadata_key:
@@ -156,13 +176,18 @@ data:
           {{- if .Values.gateway.envoy.circuitBreakers.enabled }}
           circuit_breakers:
             thresholds:
-            {{- range .Values.gateway.envoy.circuitBreakers.thresholds }}
-            - priority: {{ .priority }}
-              max_connections: {{ .maxConnections }}
-              max_pending_requests: {{ .maxPendingRequests }}
-              max_requests: {{ .maxRequests }}
-              max_retries: {{ .maxRetries }}
-            {{- end }}
+            - priority: DEFAULT
+              max_connections: {{ int .Values.gateway.envoy.circuitBreakers.maxConnections }}
+              max_pending_requests: {{ int .Values.gateway.envoy.circuitBreakers.maxPendingRequests }}
+              max_requests: {{ int .Values.gateway.envoy.circuitBreakers.maxRequests }}
+              max_retries: {{ int .Values.gateway.envoy.circuitBreakers.maxRetries }}
+          {{- end }}
+          {{- if .Values.gateway.envoy.tcpKeepalive.enabled }}
+          upstream_connection_options:
+            tcp_keepalive:
+              keepalive_probes: {{ .Values.gateway.envoy.tcpKeepalive.keepaliveProbes }}
+              keepalive_time: {{ .Values.gateway.envoy.tcpKeepalive.keepaliveTime }}
+              keepalive_interval: {{ .Values.gateway.envoy.tcpKeepalive.keepaliveInterval }}
           {{- end }}
         - name: manager_cluster
           type: STRICT_DNS
@@ -177,9 +202,10 @@ data:
                         socket_address:
                           address: sandbox-manager.{{ .Release.Namespace }}.svc.cluster.local
                           port_value: 7788
+    {{- if .Values.gateway.envoy.prometheus.enabled }}
         - name: admin_cluster
           type: STATIC
-          connect_timeout: 5s
+          connect_timeout: {{ .Values.gateway.envoy.connectTimeout }}
           lb_policy: ROUND_ROBIN
           load_assignment:
             cluster_name: admin_cluster
@@ -188,5 +214,6 @@ data:
                   - endpoint:
                       address:
                         socket_address:
-                          address: 127.0.0.1
-                          port_value: 9901
+                          address: {{ .Values.gateway.envoy.admin.address }}
+                          port_value: {{ .Values.gateway.envoy.admin.port }}
+    {{- end }}

--- a/versions/kruise-agents-sandbox-manager/next/templates/ingress.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/ingress.yaml
@@ -1,57 +1,66 @@
+{{- $domains := concat (list .Values.e2b.domain) (default (list) .Values.e2b.extraDomains) | compact | uniq }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "sandbox-manager.fullname" . }}
   labels:
     {{- include "sandbox-manager.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTPS": 443}]'
-  {{- end }}
 spec:
-  ingressClassName: {{ required "ingress.className is required" .Values.ingress.className }}
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
   tls:
     - hosts:
-        - "api.{{ .Values.e2b.domain }}"
-        - "*.{{ .Values.e2b.domain }}"
-        - "{{ .Values.e2b.domain }}"
+        {{- range $domains }}
+        - "api.{{ . }}"
+        - "*.{{ . }}"
+        - "{{ . }}"
+        {{- end }}
       secretName: "{{ .Values.ingress.certSecretName }}"
   rules:
-    - host: 'api.{{ .Values.e2b.domain }}'
+    {{- range $domains }}
+    # Control Plane
+    - host: 'api.{{ . }}'
       http:
         paths:
           - backend:
               service:
-                name: {{ include "sandbox-manager.fullname" . }}
+                name: {{ include "sandbox-manager.fullname" $ }}
                 port:
                   number: 7788
             path: /
             pathType: Prefix
-    - host: '*.{{ .Values.e2b.domain }}'
+    # Data Plane
+    - host: '*.{{ . }}'
       http:
         paths:
           - backend:
               service:
-                name: {{ .Values.ingress.dataplaneService }}
+                name: {{ $.Values.ingress.dataplaneService }}
                 port:
                   number: 7788
             path: /
             pathType: Prefix
-    - host: {{ .Values.e2b.domain }}
+    - host: '{{ . }}'
       http:
         paths:
           - backend:
               service:
-                name: {{ include "sandbox-manager.fullname" . }}
+                name: {{ include "sandbox-manager.fullname" $ }}
                 port:
                   number: 7788
             path: /kruise/api
             pathType: Prefix
           - backend:
               service:
-                name: {{ .Values.ingress.dataplaneService }}
+                name: {{ $.Values.ingress.dataplaneService }}
                 port:
                   number: 7788
             path: /
             pathType: Prefix
+    {{- end }}

--- a/versions/kruise-agents-sandbox-manager/next/templates/sandbox-gateway.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/sandbox-gateway.yaml
@@ -84,6 +84,11 @@ spec:
             - name: http
               containerPort: {{ .Values.gateway.envoy.listener.port }}
               protocol: TCP
+            {{- if .Values.gateway.envoy.prometheus.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.gateway.envoy.prometheus.port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.gateway.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/versions/kruise-agents-sandbox-manager/next/templates/secret.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/secret.yaml
@@ -20,6 +20,7 @@ metadata:
     {{- include "sandbox-manager.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  E2B_ADMIN_KEY: {{ .Values.e2b.adminApiKey | quote }}
   E2B_KEY_STORAGE_DSN: {{ .Values.e2b.keyStorage.mysql.dsn | quote }}
   E2B_KEY_HASH_PEPPER: {{ .Values.e2b.keyStorage.mysql.hashPepper | quote }}
   QUOTA_REDIS_USERNAME: {{ .Values.quota.redis.username | quote }}

--- a/versions/kruise-agents-sandbox-manager/next/templates/secret.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/secret.yaml
@@ -10,3 +10,17 @@ metadata:
     {{- include "sandbox-manager.labels" . | nindent 4 }}
 type: Opaque
 data: {{ if $existing }}{{ toJson $existing.data }}{{ else }}{}{{ end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sandbox-manager.fullname" . }}-runtime-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sandbox-manager.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  E2B_KEY_STORAGE_DSN: {{ .Values.e2b.keyStorage.mysql.dsn | quote }}
+  E2B_KEY_HASH_PEPPER: {{ .Values.e2b.keyStorage.mysql.hashPepper | quote }}
+  QUOTA_REDIS_USERNAME: {{ .Values.quota.redis.username | quote }}
+  QUOTA_REDIS_PASSWORD: {{ .Values.quota.redis.password | quote }}

--- a/versions/kruise-agents-sandbox-manager/next/templates/service.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/service.yaml
@@ -44,5 +44,11 @@ spec:
       targetPort: {{ .Values.gateway.service.targetPort }}
       protocol: TCP
       name: http
+    {{- if .Values.gateway.envoy.prometheus.enabled }}
+    - port: {{ .Values.gateway.envoy.prometheus.port }}
+      targetPort: {{ .Values.gateway.envoy.prometheus.port }}
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "sandbox-gateway.selectorLabels" . | nindent 4 }}

--- a/versions/kruise-agents-sandbox-manager/next/templates/servicemonitor.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/templates/servicemonitor.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "sandbox-manager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sandbox-manager.labels" . | nindent 4 }}
+  annotations:
+    arms.prometheus.io/discovery: 'true'
+spec:
+  endpoints:
+    - interval: 30s
+      port: manager
+      path: /metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "sandbox-manager.selectorLabels" . | nindent 6 }}
+{{- if .Values.gateway.envoy.prometheus.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sandbox-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sandbox-gateway.labels" . | nindent 4 }}
+  annotations:
+    arms.prometheus.io/discovery: 'true'
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      path: {{ .Values.gateway.envoy.prometheus.path }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "sandbox-gateway.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/versions/kruise-agents-sandbox-manager/next/values.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/values.yaml
@@ -5,9 +5,23 @@ replicaCount: 2
 
 e2b:
   domain: "your.domain.com"
+  extraDomains: []
   enableAuth: true
   adminApiKey: ""
   maxTimeout: 2592000
+  keyStorage:
+    mode: mysql
+    mysql:
+      dsn: ""
+      hashPepper: ""
+
+quota:
+  enabled: false
+  redis:
+    addr: ""
+    db: 0
+    username: ""
+    password: ""
 
 controller:
   repository: openkruise/sandbox-manager
@@ -37,6 +51,9 @@ ingress:
   annotations: { }
   certSecretName: sandbox-manager-tls
   dataplaneService: sandbox-gateway
+
+prometheus:
+  enabled: false
 
 imagePullSecrets: { }
 nameOverride: ""
@@ -81,6 +98,9 @@ affinity:
               app.kubernetes.io/instance: agents-sandbox-manager
               component: agents-sandbox-manager
           topologyKey: kubernetes.io/hostname
+
+gracefulShutdown:
+  preStopSleepSeconds: 0
 
 gateway:
   replicaCount: 2
@@ -142,6 +162,12 @@ gateway:
     admin:
       address: 127.0.0.1
       port: 9901
+    # -- Prometheus metrics endpoint (exposed externally; proxies to admin /stats/prometheus)
+    prometheus:
+      enabled: false
+      address: 0.0.0.0
+      port: 9902
+      path: /metrics
     listener:
       address: 0.0.0.0
       port: 7788
@@ -152,21 +178,29 @@ gateway:
       pluginName: sandbox-gateway
     circuitBreakers:
       enabled: true
-      thresholds:
-        - priority: DEFAULT
-          maxConnections: 80000
-          maxPendingRequests: 32768
-          maxRequests: 80000
-          maxRetries: 5
+      maxConnections: 80000
+      maxPendingRequests: 32768
+      maxRequests: 80000
+      maxRetries: 5
     concurrency: ""
     drainTimeSeconds: 30
     streamIdleTimeout: "600s"
     connectTimeout: "5s"
+    useDownstreamProtocolConfig: false
+    perConnectionBufferLimitBytes: 1048576
+    tcpKeepalive:
+      enabled: false
+      keepaliveProbes: 3
+      keepaliveTime: 60
+      keepaliveInterval: 10
     pluginConfig:
       hostHeaderName: Host
       sandboxHeaderName: e2b-sandbox-id
       sandboxPortHeader: e2b-sandbox-port
       defaultPort: "49983"
+      enableAuth: true
+      trafficAccessTokenHeader: e2b-traffic-access-token
+      enableJwtAuth: false
   service:
     type: ClusterIP
     port: 7788


### PR DESCRIPTION
## Summary
- Add startup parameters to `kruise-agents-sandbox-controller`: worker concurrency (`--sandbox-workers`, `--sandboxset-workers`, `--sandboxclaim-workers`) and client rate limits (`--client-qps`, `--client-burst`).
- Extend `kruise-agents-sandbox-manager` configuration surface:
  - Controller deployment: configurable DNS policy, runtime secrets (`E2B_ADMIN_KEY`, key-storage, quota Redis) loaded from a dedicated Secret via `--secret-config`, and graceful shutdown options.
  - Gateway Envoy config: configurable per-connection buffer limits, TCP keepalive, downstream protocol selection, circuit breaker thresholds, and access-log fields.
  - Ingress: support for multiple domains and always-on TLS.
  - Observability: optional Prometheus metrics port on the gateway and ServiceMonitor resources.
- Set `gateway.envoy.pluginConfig.enableAuth=true` and `enableJwtAuth=false` by default.

## Test plan
- [x] `helm template` renders correctly with default values.
- [x] `helm template` renders correctly with `--set gateway.envoy.pluginConfig.enableJwtAuth=true`.
- [x] `helm lint` passes for both updated charts.