### PR TITLE
feat(sandbox-controller): add commit job image and worker options

### DIFF
--- a/versions/kruise-agents-sandbox-controller/next/Chart.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/Chart.yaml
@@ -18,4 +18,6 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - "[Added]: support injecting the agent-runtime native sidecar via the agent-runtime entry of the sandbox-injection-config ConfigMap"
+    - "[Added]: configure the Commit job image through the AGENT_JOB_IMAGE environment variable of the controller"
+    - "[Added]: make the sandboxupdateops, poolautoscaler and commit reconciler worker counts configurable"
     - "[Changed]: https://github.com/openkruise/agents/blob/master/CHANGELOG.md"

--- a/versions/kruise-agents-sandbox-controller/next/README.md
+++ b/versions/kruise-agents-sandbox-controller/next/README.md
@@ -36,6 +36,8 @@ The following table lists the configurable parameters of the agents-sandbox-cont
 | `agentRuntime.image.repository` | Injected agent-runtime sidecar image repository | `openkruise/agent-runtime` |
 | `agentRuntime.image.tag` | Injected agent-runtime sidecar image tag | `v0.2.0` |
 | `agentRuntime.image.pullPolicy` | Injected agent-runtime sidecar image pull policy | `IfNotPresent` |
+| `commitJob.image.repository` | Image repository of the Commit job pods | `openkruise/commit-job` |
+| `commitJob.image.tag` | Image tag of the Commit job pods | `v0.3.0` |
 | `agentio.trafficProxy.controlPlaneNamespace` | Namespace containing the Agentio control plane | `agentio-system` |
 | `agentio.trafficProxy.controlPlaneService` | Agentio control-plane Service name | `agentiod` |
 | `agentio.trafficProxy.xdsAddress` | Explicit XDS address; generated from service and namespace when empty | `""` |

--- a/versions/kruise-agents-sandbox-controller/next/templates/deployment.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/templates/deployment.yaml
@@ -41,10 +41,16 @@ spec:
             - --sandbox-workers={{ .Values.controller.workers.sandboxWorkers }}
             - --sandboxset-workers={{ .Values.controller.workers.sandboxsetWorkers }}
             - --sandboxclaim-workers={{ .Values.controller.workers.sandboxclaimWorkers }}
+            - --sandboxupdateops-workers={{ .Values.controller.workers.sandboxupdateopsWorkers }}
+            - --poolautoscaler-workers={{ .Values.controller.workers.poolautoscalerWorkers }}
+            - --commit-workers={{ .Values.controller.workers.commitWorkers }}
             - --client-qps={{ .Values.controller.clientQPS }}
             - --client-burst={{ .Values.controller.clientBurst }}
           command:
             - /manager
+          env:
+            - name: AGENT_JOB_IMAGE
+              value: {{ printf "%s:%s" .Values.commitJob.image.repository .Values.commitJob.image.tag | quote }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:

--- a/versions/kruise-agents-sandbox-controller/next/values.yaml
+++ b/versions/kruise-agents-sandbox-controller/next/values.yaml
@@ -36,6 +36,9 @@ controller:
     sandboxWorkers: 200
     sandboxsetWorkers: 10
     sandboxclaimWorkers: 200
+    sandboxupdateopsWorkers: 5
+    poolautoscalerWorkers: 3
+    commitWorkers: 5
   # Kubernetes API client rate limit
   clientQPS: 30000
   clientBurst: 60000
@@ -98,6 +101,13 @@ agentRuntime:
     repository: openkruise/agent-runtime
     tag: v0.2.0
     pullPolicy: IfNotPresent
+
+# Image used by the Job pods the controller creates for Commit CRs.
+# Rendered into the controller's AGENT_JOB_IMAGE environment variable.
+commitJob:
+  image:
+    repository: openkruise/commit-job
+    tag: v0.3.0
 
 # BEGIN GENERATED AGENTIO TRAFFIC PROXY VALUES - DO NOT EDIT
 agentio:


### PR DESCRIPTION
## Summary

- Set `AGENT_JOB_IMAGE` on the sandbox-controller manager container, rendered from the new `commitJob.image.repository` / `commitJob.image.tag` values (defaults `openkruise/commit-job:v0.3.0`, tag tracking the controller image tag) using the same `printf "%s:%s"` form as the injected `agent-runtime` sidecar image. The controller reads this env in `pkg/controller/commit/job/config.go` to build Commit job pods, and currently errors with `env AGENT_JOB_IMAGE is empty` when it is unset.
- Expose three more reconciler worker counts through `controller.workers`: `sandboxupdateopsWorkers: 5`, `poolautoscalerWorkers: 3`, `commitWorkers: 5`, rendered as `--sandboxupdateops-workers`, `--poolautoscaler-workers` and `--commit-workers`. Flag names match the upstream definitions in `sandboxupdateops_controller.go`, `poolautoscaler_controller.go` and `commit_controller.go`.
- Document the new `commitJob.image.*` values in the chart README and record both changes in the `artifacthub.io/changes` annotation.

Changes are limited to `versions/kruise-agents-sandbox-controller/next/`; no version directory or `charts/` pointer is touched.

## Test plan

- [x] `helm lint versions/kruise-agents-sandbox-controller/next` passes
- [x] `helm template` renders `AGENT_JOB_IMAGE: "openkruise/commit-job:v0.3.0"` and `--sandboxupdateops-workers=5 --poolautoscaler-workers=3 --commit-workers=5`
- [x] `--set commitJob.image.repository=... --set commitJob.image.tag=...` and `--set controller.workers.commitWorkers=30` overrides render as expected
- [ ] `ct install` on the Kind cluster

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning) — this PR only touches the unpublished `next` pseudo-version, which already carries `version: 0.6.0` for the current cycle; the release directory and `charts/` pointer bump happen separately at release time.
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.