### PR TITLE
fix(sandbox-manager): default e2b key storage to secret

### DIFF
--- a/versions/kruise-agents-sandbox-manager/next/values.yaml
+++ b/versions/kruise-agents-sandbox-manager/next/values.yaml
@@ -10,7 +10,10 @@ e2b:
   adminApiKey: ""
   maxTimeout: 2592000
   keyStorage:
-    mode: mysql
+    # "secret" stores E2B API keys in the e2b-key-store Secret. "mysql" is also
+    # supported, but requires a non-empty dsn and hashPepper: the manager
+    # validates them at startup and exits if either is blank.
+    mode: secret
     mysql:
       dsn: ""
       hashPepper: ""


### PR DESCRIPTION
## What this PR does

Changes `e2b.keyStorage.mode` in `versions/kruise-agents-sandbox-manager/next/values.yaml` from `mysql` to `secret`, and documents in a comment that `mysql` additionally requires a non-empty `dsn` and `hashPepper`.

## Why

The `mysql` default was introduced in #195 but was never exercised: e2e installs through the `charts/kruise-agents-sandbox-manager` pointer, which still resolves to `0.3.0`. With the default values the chart renders:

```
--e2b-key-storage=mysql
--secret-config=agents-sandbox-manager-runtime-config
```

and `templates/secret.yaml` writes empty `E2B_KEY_STORAGE_DSN` / `E2B_KEY_HASH_PEPPER` into that Secret, which `--secret-config` overlays back onto the process. `keys.Config.validate()` then rejects it:

- `pkg/servers/e2b/keys/factory.go` — `mysql key storage requires a DSN`
- `pkg/servers/e2b/core.go` — `initKeyStorage` propagates the error out of `Init()`
- `cmd/sandbox-manager/main.go` — `klog.Fatalf("Failed to initialize sandbox controller: %v", err)`

So the process exits on its own and the `controller` container crash-loops. This is exactly what fails the install jobs on #197, where the pointer was moved to a `next`-derived version for the first time.

`secret` is the right default because:

- it matches the upstream `--e2b-key-storage` flag default (`pflag.StringVar(&e2bKeyStorage, "e2b-key-storage", "secret", ...)`)
- it uses the `e2b-key-store` Secret and the namespaced Role scoped to `resourceNames: [e2b-key-store]` that this chart already ships
- it is what `0.3.0` effectively ran, and `0.3.0` passes e2e on master

`mysql` stays available for operators who supply a DSN and a pepper.

## Verification

`helm template` on the patched `next` chart with the same flags the Makefile install target uses now renders `--e2b-key-storage=secret`. Diff is one file, 4 insertions / 1 deletion.

## Checklist

* [x] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning) — N/A: this only touches `next`, which is not version-bumped per PR.
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog) — N/A: `next/Chart.yaml` points at the upstream CHANGELOG.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

## Related

#197 carries the same fix for the `0.6.0-alpha2` version directory. Kept separate so this PR does not mix `next` with a version directory.