### PR TITLE
fix(kruise): always grant storageclasses RBAC to kruise-manager

### DIFF
--- a/versions/kruise/next/templates/rbac_role.yaml
+++ b/versions/kruise/next/templates/rbac_role.yaml
@@ -791,7 +791,6 @@ rules:
   - get
   - patch
   - update
-{{- if (contains "StatefulSetAutoResizePVCGate=true" .Values.featureGates) }}
 - apiGroups:
     - storage.k8s.io
   resources:
@@ -800,7 +799,6 @@ rules:
     - get
     - list
     - watch
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## What this PR does

Removes the `StatefulSetAutoResizePVCGate` conditional around the `storageclasses` RBAC rule in the kruise chart, so `kruise-manager` is always granted `get/list/watch` on `storageclasses.storage.k8s.io`.

## Why

With the gate disabled (the default), kruise-manager currently logs this error repeatedly:

```
Failed to watch *v1.StorageClass: storageclasses.storage.k8s.io is forbidden: User "system:serviceaccount:kruise-system:kruise-manager" cannot watch resource "storageclasses" in API group "storage.k8s.io" at the cluster scope
```


The conditional is wrong because the watch is not actually gated:

1. `pkg/controller/statefulset/statefulset_controller.go` creates the StorageClass informer **unconditionally** — `StatefulSetAutoResizePVCGate` only controls whether the lister is built from it:

```go
scInformer, err := cacher.GetInformerForKind(context.TODO(), storagev1.SchemeGroupVersion.WithKind("StorageClass"))

var scLister storagelisters.StorageClassLister
if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoResizePVCGate) {
    scLister = storagelisters.NewStorageClassLister(...)
}
```

The controller's own kubebuilder RBAC marker (+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch) generates the rule unconditionally in config/rbac/role.yaml.
So the chart diverged from both the runtime behavior and the code's own RBAC declaration.

Backward compatibility
No behavioral change for clusters that already set StatefulSetAutoResizePVCGate=true — the rendered ClusterRole is identical (verified with helm template; no duplicated rules). For other clusters it only silences the forbidden-watch errors.